### PR TITLE
Repo, packages, and HDFS (oh my)

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -20,4 +20,24 @@
 
 <configuration>
 
+  <property>
+    <name>root.namespace</name>
+    <value>cdap</value>
+  </property>
+
+  <property>
+    <name>hdfs.namespace</name>
+    <value>/${root.namespace}</value>
+  </property>
+
+  <property>
+    <name>hdfs.user</name>
+    <value>cdap</value>
+  </property>
+
+  <property>
+    <name>kafka.log.dir</name>
+    <value>/data/cdap-kafka/logs</value>
+  </property>
+
 </configuration>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -18,7 +18,7 @@
           <name>CDAP_AUTH_SERVER</name>
           <displayName>CDAP Auth Server</displayName>
           <category>MASTER</category>
-          <cardinality>0-2</cardinality>
+          <cardinality>0-1</cardinality>
           <commandScript>
             <script>scripts/auth.py</script>
             <scriptType>PYTHON</scriptType>
@@ -44,7 +44,7 @@
           <name>CDAP_MASTER</name>
           <displayName>CDAP Master</displayName>
           <category>MASTER</category>
-          <cardinality>1-2</cardinality>
+          <cardinality>1</cardinality>
           <commandScript>
             <script>scripts/master.py</script>
             <scriptType>PYTHON</scriptType>
@@ -67,7 +67,7 @@
           <name>CDAP_KAFKA</name>
           <displayName>CDAP Kafka Server</displayName>
           <category>MASTER</category>
-          <cardinality>1-2</cardinality>
+          <cardinality>1</cardinality>
           <commandScript>
             <script>scripts/kafka.py</script>
             <scriptType>PYTHON</scriptType>
@@ -89,7 +89,7 @@
           <name>CDAP_ROUTER</name>
           <displayName>CDAP Router</displayName>
           <category>MASTER</category>
-          <cardinality>1+</cardinality>
+          <cardinality>1</cardinality>
           <commandScript>
             <script>scripts/router.py</script>
             <scriptType>PYTHON</scriptType>
@@ -111,7 +111,7 @@
           <name>CDAP_UI</name>
           <displayName>CDAP UI</displayName>
           <category>MASTER</category>
-          <cardinality>1+</cardinality>
+          <cardinality>1</cardinality>
           <commandScript>
             <script>scripts/ui.py</script>
             <scriptType>PYTHON</scriptType>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -59,6 +59,34 @@
                 <co-locate>CDAP/CDAP_MASTER</co-locate>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>YARN/YARN_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>YARN/MAPREDUCE2_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>HDFS/HDFS_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>HBASE/HBASE_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -19,6 +19,7 @@
           <displayName>CDAP Auth Server</displayName>
           <category>MASTER</category>
           <cardinality>0-1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
           <commandScript>
             <script>scripts/auth.py</script>
             <scriptType>PYTHON</scriptType>
@@ -32,6 +33,7 @@
           <displayName>CDAP CLI</displayName>
           <category>CLIENT</category>
           <cardinality>1+</cardinality>
+          <versionAdvertised>true</versionAdvertised>
           <commandScript>
             <script>scripts/cli.py</script>
             <scriptType>PYTHON</scriptType>
@@ -45,6 +47,7 @@
           <displayName>CDAP Master</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
           <commandScript>
             <script>scripts/master.py</script>
             <scriptType>PYTHON</scriptType>
@@ -96,6 +99,7 @@
           <displayName>CDAP Kafka Server</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
           <commandScript>
             <script>scripts/kafka.py</script>
             <scriptType>PYTHON</scriptType>
@@ -118,6 +122,7 @@
           <displayName>CDAP Router</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
           <commandScript>
             <script>scripts/router.py</script>
             <scriptType>PYTHON</scriptType>
@@ -140,6 +145,7 @@
           <displayName>CDAP UI</displayName>
           <category>MASTER</category>
           <cardinality>1</cardinality>
+          <versionAdvertised>true</versionAdvertised>
           <commandScript>
             <script>scripts/ui.py</script>
             <scriptType>PYTHON</scriptType>

--- a/package/files/cdap.list
+++ b/package/files/cdap.list
@@ -1,0 +1,1 @@
+deb [ arch=amd64 ] http://repository.cask.co/ubuntu/precise/amd64/cdap/3.0 precise cdap

--- a/package/files/cdap.repo
+++ b/package/files/cdap.repo
@@ -1,0 +1,5 @@
+[CDAP-3.0]
+name=Cask Data Application Platform Packages
+baseurl=http://repository.cask.co/centos/6/x86_64/cdap/3.0
+enabled=1
+gpgcheck=1

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -1,0 +1,14 @@
+from resource_management import *
+import os
+
+def create_hdfs_dir(path, owner, perms):
+  Execute('hadoop fs -mkdir -p '+path, user='hdfs')
+  Execute('hadoop fs -chown ' + owner + ' ' + path, user='hdfs')
+  Execute('hadoop fs -chmod ' + perms + ' ' + path, user='hdfs')
+
+def package(name):
+  Execute(package_mgr + ' install -y ' + name, user='root')
+
+def add_repo(source, dest):
+  if not os.path.isfile(dest + repo_file):
+    Execute('cp ' + source + ' ' + dest)

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -14,14 +14,23 @@ class Auth(Script):
     # Install package
     helpers.package('cdap-security')
 
-  def stop(self, env):
-    print 'Stop the CDAP Auth Server';
-
   def start(self, env):
     print 'Start the CDAP Auth Server';
+    import params
+    self.configure(env)
+    Execute('service cdap-auth-server start')
+
+  def stop(self, env):
+    print 'Stop the CDAP Auth Server';
+    import params
+    self.configure(env)
+    Execute('service cdap-auth-server stop')
 
   def status(self, env):
     print 'Status of the CDAP Auth Server';
+    import params
+    self.configure(env)
+    Execute('service cdap-auth-server status')
 
   def configure(self, env):
     print 'Configure the CDAP Auth Server';

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -1,9 +1,18 @@
 import sys
+import ambari_helpers as helpers
 from resource_management import *
 
 class Auth(Script):
   def install(self, env):
     print 'Install the CDAP Auth Server';
+    import params
+    self.configure(env)
+    # Add repository file
+    helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
+    # Install package
+    helpers.package('cdap-security')
 
   def stop(self, env):
     print 'Stop the CDAP Auth Server';

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -1,9 +1,18 @@
 import sys
+import ambari_helpers as helpers
 from resource_management import *
 
 class Kafka(Script):
   def install(self, env):
     print 'Install the CDAP Kafka Server';
+    import params
+    self.configure(env)
+    # Add repository file
+    helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
+    # Install package
+    helpers.package('cdap-kafka')
 
   def stop(self, env):
     print 'Stop the CDAP Kafka Server';

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -18,6 +18,7 @@ class Kafka(Script):
     print 'Start the CDAP Kafka Server';
     import params
     self.configure(env)
+    Execute('mkdir -p ' + params.kafka_log_dir)
     Execute('service cdap-kafka-server start')
 
   def stop(self, env):

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -14,14 +14,23 @@ class Kafka(Script):
     # Install package
     helpers.package('cdap-kafka')
 
-  def stop(self, env):
-    print 'Stop the CDAP Kafka Server';
-
   def start(self, env):
     print 'Start the CDAP Kafka Server';
+    import params
+    self.configure(env)
+    Execute('service cdap-kafka-server start')
+
+  def stop(self, env):
+    print 'Stop the CDAP Kafka Server';
+    import params
+    self.configure(env)
+    Execute('service cdap-kafka-server stop')
 
   def status(self, env):
     print 'Status of the CDAP Kafka Server';
+    import params
+    self.configure(env)
+    Execute('service cdap-kafka-server status')
 
   def configure(self, env):
     print 'Configure the CDAP Kafka Server';

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -1,15 +1,24 @@
 import sys
+import ambari_helpers as helpers
 from resource_management import *
 
 class Master(Script):
   def install(self, env):
     print 'Install the CDAP Master';
-
-  def stop(self, env):
-    print 'Stop the CDAP Master';
+    import params
+    self.configure(env)
+    # Add repository file
+    helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
+    # Install package
+    helpers.package('cdap-master')
 
   def start(self, env):
     print 'Start the CDAP Master';
+
+  def stop(self, env):
+    print 'Stop the CDAP Master';
 
   def status(self, env):
     print 'Status of the CDAP Master';

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -16,12 +16,21 @@ class Master(Script):
 
   def start(self, env):
     print 'Start the CDAP Master';
+    import params
+    self.configure(env)
+    Execute('service cdap-master start')
 
   def stop(self, env):
     print 'Stop the CDAP Master';
+    import params
+    self.configure(env)
+    Execute('service cdap-master stop')
 
   def status(self, env):
     print 'Status of the CDAP Master';
+    import params
+    self.configure(env)
+    Execute('service cdap-master status')
 
   def configure(self, env):
     print 'Configure the CDAP Master';

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -18,6 +18,7 @@ class Master(Script):
     print 'Start the CDAP Master';
     import params
     self.configure(env)
+    create_hdfs_dir(params.hdfs_namespace, params.hdfs_user, 755)
     Execute('service cdap-master start')
 
   def stop(self, env):

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -23,10 +23,11 @@ else
 cdap_user = "cdap"
 cdap_conf_dir = "/etc/cdap/conf"
 dfs = config['configurations']['core-site']['fs.defaultFS']
-cdap_site = config['configurations']['cdap-site'];
+security_enabled = config['configurations']['cluster-env']['security_enabled']
+map_cdap_site = config['configurations']['cdap-site'];
 
 # Example: root.namespace
-root_namespace = cdap_site['root.namespace']
-hdfs_namespace = cdap_site['hdfs.namespace']
-hdfs_user = cdap_site['hdfs.user']
-kafka_log_dir = cdap_site['kafka.log.dir']
+root_namespace = map_cdap_site['root.namespace']
+hdfs_namespace = map_cdap_site['hdfs.namespace']
+hdfs_user = map_cdap_site['hdfs.user']
+kafka_log_dir = map_cdap_site['kafka.log.dir']

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -1,0 +1,32 @@
+from resource_management import *
+from resource_management.libraries.functions.version import format_hdp_stack_version, compare_versions
+import os
+
+# config object that holds the configurations declared in the -config.xml file
+config = Script.get_config()
+
+stack_dir = os.path.realpath(__file__).split('/scripts')[0]
+caskckage_dir = os.path.realpath(__file__).split('/package')[0] + '/package/'
+files_dir = package_dir + 'files/'
+scripts_dir = package_dir + 'scripts/'
+distribution = platform.linux_distribution()[0].lower()
+
+if distribution in ['centos', 'redhat'] :
+  os_repo_dir = '/etc/yum.repos.d/'
+  repo_file = 'cdap.repo'
+  package_mgr = 'yum'
+else
+  os_repo_dir = '/etc/apt/sources.list.d/'
+  repo_file = 'cdap.list'
+  package_mgr = 'apt-get'
+
+cdap_user = "cdap"
+cdap_conf_dir = "/etc/cdap/conf"
+dfs = config['configurations']['core-site']['fs.defaultFS']
+cdap_site = config['configurations']['cdap-site'];
+
+# Example: root.namespace
+root_namespace = cdap_site['root.namespace']
+hdfs_namespace = cdap_site['hdfs.namespace']
+hdfs_user = cdap_site['hdfs.user']
+kafka_log_dir = cdap_site['kafka.log.dir']

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -6,7 +6,7 @@ import os
 config = Script.get_config()
 
 stack_dir = os.path.realpath(__file__).split('/scripts')[0]
-caskckage_dir = os.path.realpath(__file__).split('/package')[0] + '/package/'
+package_dir = os.path.realpath(__file__).split('/package')[0] + '/package/'
 files_dir = package_dir + 'files/'
 scripts_dir = package_dir + 'scripts/'
 distribution = platform.linux_distribution()[0].lower()

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -1,9 +1,18 @@
 import sys
+import ambari_helpers as helpers
 from resource_management import *
 
 class Router(Script):
   def install(self, env):
     print 'Install the CDAP Router';
+    import params
+    self.configure(env)
+    # Add repository file
+    helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
+    # Install package
+    helpers.package('cdap-gateway')
 
   def stop(self, env):
     print 'Stop the CDAP Router';

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -14,14 +14,23 @@ class Router(Script):
     # Install package
     helpers.package('cdap-gateway')
 
-  def stop(self, env):
-    print 'Stop the CDAP Router';
-
   def start(self, env):
     print 'Start the CDAP Router';
+    import params
+    self.configure(env)
+    Execute('service cdap-router start')
+
+  def stop(self, env):
+    print 'Stop the CDAP Router';
+    import params
+    self.configure(env)
+    Execute('service cdap-router stop')
 
   def status(self, env):
     print 'Status of the CDAP Router';
+    import params
+    self.configure(env)
+    Execute('service cdap-router status')
 
   def configure(self, env):
     print 'Configure the CDAP Router';

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -1,9 +1,18 @@
 import sys
+import ambari_helpers as helpers
 from resource_management import *
 
 class UI(Script):
   def install(self, env):
     print 'Install the CDAP UI';
+    import params
+    self.configure(env)
+    # Add repository file
+    helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
+    # Install package
+    helpers.package('cdap-ui')
 
   def stop(self, env):
     print 'Stop the CDAP UI';

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -14,14 +14,23 @@ class UI(Script):
     # Install package
     helpers.package('cdap-ui')
 
-  def stop(self, env):
-    print 'Stop the CDAP UI';
-
   def start(self, env):
     print 'Start the CDAP UI';
+    import params
+    self.configure(env)
+    Execute('service cdap-ui start')
+
+  def stop(self, env):
+    print 'Stop the CDAP UI';
+    import params
+    self.configure(env)
+    Execute('service cdap-ui stop')
 
   def status(self, env):
     print 'Status of the CDAP UI';
+    import params
+    self.configure(env)
+    Execute('service cdap-ui status')
 
   def configure(self, env):
     print 'Configure the CDAP UI';

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -13,6 +13,8 @@ class UI(Script):
     self.install_packages(env)
     # Install package
     helpers.package('cdap-ui')
+    # TODO: make sure this is available
+    helpers.package('nodejs')
 
   def start(self, env):
     print 'Start the CDAP UI';


### PR DESCRIPTION
This is the basics for single-node functionality.
- Sets cardinality to only allow a single CDAP node
- Installs client packages on CDAP Master node
- Create repository for APT/YUM
- Install packages from repository
- Start/Stop/Status via init scripts
- Create HDFS `hdfs.namespace` directory
- Create Kafka `kafka.log.dir` directory
- Install `nodejs` on CDAP UI node, assuming it's available
