### PR TITLE
Config files (part 1)

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -40,4 +40,24 @@
     <value>/data/cdap-kafka/logs</value>
   </property>
 
+  <property>
+    <name>kafka.seed.brokers</name>
+    <value>localhost:9092</value>
+  </property>
+
+  <property>
+    <name>kafka.default.replication.factor</name>
+    <value>1</value>
+  </property>
+
+  <property>
+    <name>log.retention.duration.days</name>
+    <value>7</value>
+  </property>
+
+  <property>
+    <name>zookeeper.quorum</name>
+    <value>localhost:2181/${root.namespace}</value>
+  </property>
+
 </configuration>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -57,7 +57,7 @@
 
   <property>
     <name>zookeeper.quorum</name>
-    <value>localhost:2181/${root.namespace}</value>
+    <value>{{cdap_zookeeper_quorum}}</value>
   </property>
 
   <property>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -60,4 +60,19 @@
     <value>localhost:2181/${root.namespace}</value>
   </property>
 
+  <property>
+    <name>router.bind.address</name>
+    <value>localhost</value>
+  </property>
+
+  <property>
+    <name>router.server.address</name>
+    <value>${router.bind.address}</value>
+  </property>
+
+  <property>
+    <name>dashboard.bind.port</name>
+    <value>9999</value>
+  </property>
+
 </configuration>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -26,6 +26,15 @@
             <scriptType>PYTHON</scriptType>
             <timeout>600</timeout>
           </commandScript>
+          <dependencies>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+          </dependencies>
         </component>
 
         <component>
@@ -103,6 +112,13 @@
                 <enabled>true</enabled>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 
@@ -127,6 +143,13 @@
                 <co-locate>CDAP/CDAP_MASTER</co-locate>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 
@@ -148,6 +171,13 @@
               <auto-deploy>
                 <enabled>true</enabled>
                 <co-locate>CDAP/CDAP_MASTER</co-locate>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
               </auto-deploy>
             </dependency>
           </dependencies>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -40,6 +40,18 @@
             <scriptType>PYTHON</scriptType>
             <timeout>600</timeout>
           </commandScript>
+          <configFiles>
+            <configFile>
+              <type>xml</type>
+              <fileName>cdap-site.xml</fileName>
+              <dictionaryName>cdap-site</dictionaryName>
+            </configFile>
+            <configFile>
+              <type>env</type>
+              <fileName>cdap-env.sh</fileName>
+              <dictionaryName>cdap-env</dictionaryName>
+            </configFile>
+          <configFiles>
         </component>
 
         <component>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -34,6 +34,13 @@
                 <enabled>true</enabled>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>HBASE/HBASE_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 
@@ -150,6 +157,13 @@
                 <enabled>true</enabled>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>HBASE/HBASE_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 
@@ -175,6 +189,13 @@
             </dependency>
             <dependency>
               <name>ZOOKEEPER/ZOOKEEPER_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>HBASE/HBASE_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -31,7 +31,7 @@
         <component>
           <!-- CDAP CLI -->
           <name>CDAP_CLI</name>
-          <displayName>CDAP CLI</displayName>
+          <displayName>CDAP CLI Client</displayName>
           <category>CLIENT</category>
           <cardinality>1+</cardinality>
           <versionAdvertised>true</versionAdvertised>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -51,7 +51,7 @@
               <fileName>cdap-env.sh</fileName>
               <dictionaryName>cdap-env</dictionaryName>
             </configFile>
-          <configFiles>
+          </configFiles>
         </component>
 
         <component>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -14,8 +14,10 @@
 
       <components>
 
+        <!--
+          This is currently commented to focus on core CDAP without perimeter security
         <component>
-          <!-- CDAP Auth Server-->
+          <!-- CDAP Auth Server #-->
           <name>CDAP_AUTH_SERVER</name>
           <displayName>CDAP Auth Server</displayName>
           <category>MASTER</category>
@@ -43,6 +45,7 @@
             </dependency>
           </dependencies>
         </component>
+        -->
 
         <component>
           <!-- CDAP CLI -->

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -34,7 +34,6 @@ def cdap_config(name=None):
   XmlConfig( "cdap-site.xml",
             conf_dir = params.cdap_conf_dir,
             configurations = params.config['configurations']['cdap-site'],
-            configuration_attributes=params.config['configuration_attributes']['cdap-site'],
             owner = params.cdap_user,
             group = params.user_group
   )

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -16,3 +16,29 @@ def add_repo(source, dest):
     Execute('cp ' + source + ' ' + dest)
     Execute(params.key_cmd)
     Execute(params.cache_cmd)
+
+def cdap_config():
+  import params
+  # We're only setup for *NIX, for now
+  Directory( params.etc_prefix_dir,
+      mode=0755
+  )
+
+  Directory( params.cdap_conf_dir,
+      owner = params.cdap_user,
+      group = params.user_group,
+      recursive = True
+  )
+
+  XmlConfig( "cdap-site.xml",
+            conf_dir = params.cdap_conf_dir,
+            configurations = params.config['configurations']['cdap-site'],
+            configuration_attributes=params.config['configuration_attributes']['cdap-site'],
+            owner = params.cdap_user,
+            group = params.user_group
+  )
+
+  File(format("{cdap_conf_dir}/cdap-env.sh"),
+       owner = params.cdap_user,
+       content=InlineTemplate(params.cdap_env_sh_template)
+  )

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -43,3 +43,5 @@ def cdap_config(name=None):
        owner = params.cdap_user,
        content=InlineTemplate(params.cdap_env_sh_template)
   )
+
+  Execute('update-alternatives --install /etc/cdap/conf cdap-conf /etc/cdap/' + params.cdap_conf_dir + ' 50')

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -4,7 +4,7 @@ import os
 def create_hdfs_dir(path, owner, perms):
   Execute('hadoop fs -mkdir -p '+path, user='hdfs')
   Execute('hadoop fs -chown ' + owner + ' ' + path, user='hdfs')
-  Execute('hadoop fs -chmod ' + perms + ' ' + path, user='hdfs')
+  Execute('hadoop fs -chmod ' + str(perms) + ' ' + path, user='hdfs')
 
 def package(name):
   import params

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -43,4 +43,4 @@ def cdap_config(name=None):
        content=InlineTemplate(params.cdap_env_sh_template)
   )
 
-  Execute('update-alternatives --install /etc/cdap/conf cdap-conf /etc/cdap/' + params.cdap_conf_dir + ' 50')
+  Execute('update-alternatives --install /etc/cdap/conf cdap-conf ' + params.cdap_conf_dir + ' 50')

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -39,7 +39,7 @@ def cdap_config(name=None):
             group = params.user_group
   )
 
-  File(format("{cdap_conf_dir}/cdap-env.sh"),
+  File(format("{params.cdap_conf_dir}/cdap-env.sh"),
        owner = params.cdap_user,
        content=InlineTemplate(params.cdap_env_sh_template)
   )

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -17,7 +17,7 @@ def add_repo(source, dest):
     Execute(params.key_cmd)
     Execute(params.cache_cmd)
 
-def cdap_config():
+def cdap_config:
   import params
   # We're only setup for *NIX, for now
   Directory( params.etc_prefix_dir,

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -17,8 +17,9 @@ def add_repo(source, dest):
     Execute(params.key_cmd)
     Execute(params.cache_cmd)
 
-def cdap_config:
+def cdap_config(name=None):
   import params
+  print 'Setting up CDAP configuration for ' + name
   # We're only setup for *NIX, for now
   Directory( params.etc_prefix_dir,
       mode=0755

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -35,6 +35,7 @@ class Auth(Script):
   def configure(self, env):
     print 'Configure the CDAP Auth Server'
     import params
+    env.set_params(params)
     helpers.cdap_config('auth')
 
 if __name__ == "__main__":

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -35,7 +35,7 @@ class Auth(Script):
   def configure(self, env):
     print 'Configure the CDAP Auth Server'
     import params
-    helpers.cdap_config
+    helpers.cdap_config('auth')
 
 if __name__ == "__main__":
   Auth().execute()

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -34,6 +34,8 @@ class Auth(Script):
 
   def configure(self, env):
     print 'Configure the CDAP Auth Server'
+    import params
+    helpers.cdap_config
 
 if __name__ == "__main__":
   Auth().execute()

--- a/package/scripts/cli.py
+++ b/package/scripts/cli.py
@@ -7,6 +7,8 @@ class CLI(Script):
 
   def configure(self, env):
     print 'Configure the CDAP CLI'
+    import params
+    helpers.cdap_config
 
   def status(self, env):
     raise ClientComponentHasNoStatus()

--- a/package/scripts/cli.py
+++ b/package/scripts/cli.py
@@ -8,7 +8,7 @@ class CLI(Script):
   def configure(self, env):
     print 'Configure the CDAP CLI'
     import params
-    helpers.cdap_config
+    helpers.cdap_config('client')
 
   def status(self, env):
     raise ClientComponentHasNoStatus()

--- a/package/scripts/cli.py
+++ b/package/scripts/cli.py
@@ -8,6 +8,7 @@ class CLI(Script):
   def configure(self, env):
     print 'Configure the CDAP CLI'
     import params
+    env.set_params(params)
     helpers.cdap_config('client')
 
   def status(self, env):

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -36,7 +36,7 @@ class Kafka(Script):
   def configure(self, env):
     print 'Configure the CDAP Kafka Server'
     import params
-    helpers.cdap_config
+    helpers.cdap_config('kafka')
 
 if __name__ == "__main__":
   Kafka().execute()

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -36,6 +36,7 @@ class Kafka(Script):
   def configure(self, env):
     print 'Configure the CDAP Kafka Server'
     import params
+    env.set_params(params)
     helpers.cdap_config('kafka')
 
 if __name__ == "__main__":

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -35,6 +35,8 @@ class Kafka(Script):
 
   def configure(self, env):
     print 'Configure the CDAP Kafka Server'
+    import params
+    helpers.cdap_config
 
 if __name__ == "__main__":
   Kafka().execute()

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -18,7 +18,7 @@ class Master(Script):
     print 'Start the CDAP Master'
     import params
     self.configure(env)
-    create_hdfs_dir(params.hdfs_namespace, params.hdfs_user, 755)
+    helpers.create_hdfs_dir(params.hdfs_namespace, params.hdfs_user, 755)
     Execute('service cdap-master start')
 
   def stop(self, env):

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -35,6 +35,8 @@ class Master(Script):
 
   def configure(self, env):
     print 'Configure the CDAP Master'
+    import params
+    helpers.cdap_config
 
 if __name__ == "__main__":
   Master().execute()

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -36,6 +36,7 @@ class Master(Script):
   def configure(self, env):
     print 'Configure the CDAP Master'
     import params
+    env.set_params(params)
     helpers.cdap_config('master')
 
 if __name__ == "__main__":

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -36,7 +36,7 @@ class Master(Script):
   def configure(self, env):
     print 'Configure the CDAP Master'
     import params
-    helpers.cdap_config
+    helpers.cdap_config('master')
 
 if __name__ == "__main__":
   Master().execute()

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -37,6 +37,9 @@ map_cdap_site = config['configurations']['cdap-site'];
 
 # Example: root.namespace
 root_namespace = map_cdap_site['root.namespace']
-hdfs_namespace = map_cdap_site['hdfs.namespace']
+if map_cdap_site['hdfs.namespace'] == '/${root.namespace}' :
+  hdfs_namespace = '/' + root_namespace
+else:
+  hdfs_namespace = map_cdap_site['hdfs.namespace']
 hdfs_user = map_cdap_site['hdfs.user']
 kafka_log_dir = map_cdap_site['kafka.log.dir']

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -33,6 +33,8 @@ dfs = config['configurations']['core-site']['fs.defaultFS']
 
 cdap_env_sh_template = config['configurations']['cdap-env']['content']
 
+cdap_zookeeper_quorum = config['configurations']['cdap-site']['zookeeper.quorum']
+
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 map_cdap_site = config['configurations']['cdap-site'];
 

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -25,8 +25,12 @@ else :
   cache_cmd = 'apt-get update'
 
 cdap_user = "cdap"
-cdap_conf_dir = "/etc/cdap/conf"
+etc_prefix_dir = "/etc/cdap"
+cdap_conf_dir = "/etc/cdap/conf.ambari"
 dfs = config['configurations']['core-site']['fs.defaultFS']
+
+cdap_env_sh_template = config['configurations']['cdap-env']['content']
+
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 map_cdap_site = config['configurations']['cdap-site'];
 

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -33,8 +33,6 @@ dfs = config['configurations']['core-site']['fs.defaultFS']
 
 cdap_env_sh_template = config['configurations']['cdap-env']['content']
 
-cdap_zookeeper_quorum = config['configurations']['cdap-site']['zookeeper.quorum']
-
 security_enabled = config['configurations']['cluster-env']['security_enabled']
 map_cdap_site = config['configurations']['cdap-site'];
 
@@ -46,3 +44,14 @@ else:
   hdfs_namespace = map_cdap_site['hdfs.namespace']
 hdfs_user = map_cdap_site['hdfs.user']
 kafka_log_dir = map_cdap_site['kafka.log.dir']
+
+# Get ZooKeeper variables
+zk_client_port = str(default('/configurations/zoo.cfg/clientPort', None))
+zk_hosts = config['clusterHostInfo']['zookeeper_hosts']
+zookeeper_hosts = ''
+# Evaluate and setup ZooKeeper quorum string
+for i, val in enumerate(zookeeper_hosts):
+  zookeeper_hosts += val + ":" + zk_client_port
+  if (i + 1) < len(zk_hosts):
+    zookeeper_hosts += ","
+cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -48,10 +48,11 @@ kafka_log_dir = map_cdap_site['kafka.log.dir']
 # Get ZooKeeper variables
 zk_client_port = str(default('/configurations/zoo.cfg/clientPort', None))
 zk_hosts = config['clusterHostInfo']['zookeeper_hosts']
+zk_hosts.sort()
 zookeeper_hosts = ''
 # Evaluate and setup ZooKeeper quorum string
 for i, val in enumerate(zk_hosts):
-  zookeeper_hosts += val + ":" + zk_client_port
+  zookeeper_hosts += val + ':' + zk_client_port
   if (i + 1) < len(zk_hosts):
-    zookeeper_hosts += ","
+    zookeeper_hosts += ','
 cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -10,6 +10,7 @@ package_dir = os.path.realpath(__file__).split('/package')[0] + '/package/'
 files_dir = package_dir + 'files/'
 scripts_dir = package_dir + 'scripts/'
 distribution = platform.linux_distribution()[0].lower()
+java64_home = config['hostLevelParams']['java_home']
 
 if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -50,7 +50,7 @@ zk_client_port = str(default('/configurations/zoo.cfg/clientPort', None))
 zk_hosts = config['clusterHostInfo']['zookeeper_hosts']
 zookeeper_hosts = ''
 # Evaluate and setup ZooKeeper quorum string
-for i, val in enumerate(zookeeper_hosts):
+for i, val in enumerate(zk_hosts):
   zookeeper_hosts += val + ":" + zk_client_port
   if (i + 1) < len(zk_hosts):
     zookeeper_hosts += ","

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -11,6 +11,7 @@ files_dir = package_dir + 'files/'
 scripts_dir = package_dir + 'scripts/'
 distribution = platform.linux_distribution()[0].lower()
 java64_home = config['hostLevelParams']['java_home']
+user_group = config['configurations']['cluster-env']['user_group']
 
 if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -35,6 +35,7 @@ class Router(Script):
   def configure(self, env):
     print 'Configure the CDAP Router'
     import params
+    env.set_params(params)
     helpers.cdap_config('router')
 
 if __name__ == "__main__":

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -35,7 +35,7 @@ class Router(Script):
   def configure(self, env):
     print 'Configure the CDAP Router'
     import params
-    helpers.cdap_config
+    helpers.cdap_config('router')
 
 if __name__ == "__main__":
   Router().execute()

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -34,6 +34,8 @@ class Router(Script):
 
   def configure(self, env):
     print 'Configure the CDAP Router'
+    import params
+    helpers.cdap_config
 
 if __name__ == "__main__":
   Router().execute()

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -37,6 +37,7 @@ class UI(Script):
   def configure(self, env):
     print 'Configure the CDAP UI'
     import params
+    env.set_params(params)
     helpers.cdap_config('ui')
 
 if __name__ == "__main__":

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -36,6 +36,8 @@ class UI(Script):
 
   def configure(self, env):
     print 'Configure the CDAP UI'
+    import params
+    helpers.cdap_config
 
 if __name__ == "__main__":
   UI().execute()

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -37,7 +37,7 @@ class UI(Script):
   def configure(self, env):
     print 'Configure the CDAP UI'
     import params
-    helpers.cdap_config
+    helpers.cdap_config('ui')
 
 if __name__ == "__main__":
   UI().execute()


### PR DESCRIPTION
This is the initial configuration files framework. There are some options in the `cdap-site.xml` file which causes them to be visible to Ambari under "Advanced cdap-site.xml settings" for the CDAP service. The `cdap_config` method in `ambari_helpers.rb` writes out the configuration files. The `params.py` script interacts with Ambari's configurations and sets variables which we can use in other places. The first example of this is `cdap_zookeeper_quorum` which is set to a proper CDAP quorum string, including ZooKeeper namespace prefix, based on the hosts with the ZooKeeper service.
