### PR TITLE
Set HADOOP_HOME in the same way as HDFS service

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -38,6 +38,11 @@ if [ "$JAVA_HOME" = "" ]; then
 fi
 
 JAVA=$JAVA_HOME/bin/java
+
+export HADOOP_HOME_WARN_SUPPRESS=1
+
+# Hadoop home directory
+export HADOOP_HOME=${HADOOP_HOME:-/usr/lib/hadoop}
     </value>
   </property>
 </configuration>


### PR DESCRIPTION
Copied from [Ambari HDFS common-services](https://github.com/apache/ambari/blob/trunk/ambari-server/src/main/resources/common-services/HDFS/2.1.0.2.0/configuration/hadoop-env.xml)
- Disable warning on missing HADOOP_HOME
- Set HADOOP_HOME to default
