### PR TITLE
Co-locate Kafka/Router with Master

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -62,7 +62,7 @@
 
   <property>
     <name>router.bind.address</name>
-    <value>localhost</value>
+    <value>{{hostname}}</value>
   </property>
 
   <property>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -41,8 +41,13 @@
   </property>
 
   <property>
+    <name>kafka.bind.port</name>
+    <value>9092</value>
+  </property>
+
+  <property>
     <name>kafka.seed.brokers</name>
-    <value>localhost:9092</value>
+    <value>{{cdap_kafka_brokers}}</value>
   </property>
 
   <property>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -84,6 +84,22 @@
           </commandScript>
           <dependencies>
             <dependency>
+              <name>CDAP/CDAP_KAFKA</name>
+              <scope>cluster</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+                <co-locate>CDAP/CDAP_MASTER</co-locate>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>CDAP/CDAP_ROUTER</name>
+              <scope>cluster</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+                <co-locate>CDAP/CDAP_MASTER</co-locate>
+              </auto-deploy>
+            </dependency>
+            <dependency>
               <name>ZOOKEEPER/ZOOKEEPER_SERVER</name>
               <scope>cluster</scope>
               <auto-deploy>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -10,6 +10,7 @@ package_dir = os.path.realpath(__file__).split('/package')[0] + '/package/'
 files_dir = package_dir + 'files/'
 scripts_dir = package_dir + 'scripts/'
 distribution = platform.linux_distribution()[0].lower()
+hostname = config['hostname']
 java64_home = config['hostLevelParams']['java_home']
 user_group = config['configurations']['cluster-env']['user_group']
 

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -57,3 +57,15 @@ for i, val in enumerate(zk_hosts):
   if (i + 1) < len(zk_hosts):
     zookeeper_hosts += ','
 cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace
+
+kafka_bind_port = str(default('/configurations/cdap-site/kafka.bind.port', None))
+kafka_hosts = config['clusterHostInfo']['cdap_kafka_hosts']
+kafka_hosts.sort()
+tmp_kafka_hosts = ''
+for i, val in enumerate(tmp_kafka_hosts):
+  tmp_kafka_hosts += val + ':' + kafka_bind_port
+  if (i + 1) < len(tmp_kafka_hosts):
+    tmp_kafka_hosts += ','
+cdap_kafka_brokers = tmp_kafka_hosts
+
+### TODO: cdap_auth_server_hosts cdap_router_hosts cdap_ui_hosts


### PR DESCRIPTION
- Set `kafka.bind.port`
- Derive `cdap_kafka_brokers` from Ambari's `clusterHostInfo['cdap_kafka_hosts']` + `kafka.bind.port`
- Set `router.bind.address` to `hostname` to force router to bind to eth0 versus localhost
- Set CDAP_KAFKA and CDAP_ROUTER as dependencies of CDAP_MASTER and co-locate them
