### PR TITLE
Make status use status_params

### DIFF
--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -34,8 +34,7 @@ class Auth(Script):
 
   def status(self, env):
     import status_params
-    env.set_params(status_params)
-    check_process_status(status_params.cdap_auth_pid_file)
+    Execute('ls ' + status_params.cdap_auth_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_auth_pid_file + ') >/dev/null 2>&1')
 
   def configure(self, env):
     print 'Configure the CDAP Auth Server'

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -33,9 +33,9 @@ class Auth(Script):
     Execute('service cdap-auth-server stop')
 
   def status(self, env):
-    import params
-    env.set_params(params)
-    check_process_status(params.cdap_auth_pid_file)
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.cdap_auth_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Auth Server'

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -17,10 +17,11 @@ class Auth(Script):
   def start(self, env):
     print 'Start the CDAP Auth Server'
     import params
+    import status_params
     env.set_params(params)
     self.configure(env)
     daemon_cmd = format('/opt/cdap/security/bin/svc-auth-server start')
-    no_op_test = format('ls {params.cdap_auth_pid_file} >/dev/null 2>&1 && ps -p $(<{params.cdap_auth_pid_file}) >/dev/null 2>&1')
+    no_op_test = format('ls {status_params.cdap_auth_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_auth_pid_file}) >/dev/null 2>&1')
     Execute( daemon_cmd,
              user=params.cdap_user,
              not_if=no_op_test

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -33,9 +33,9 @@ class Kafka(Script):
     Execute('service cdap-kafka-server stop')
 
   def status(self, env):
-    import params
-    env.set_params(params)
-    check_process_status(params.cdap_kafka_pid_file)
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.cdap_kafka_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Kafka Server'

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -17,10 +17,11 @@ class Kafka(Script):
   def start(self, env):
     print 'Start the CDAP Kafka Server'
     import params
+    import status_params
     env.set_params(params)
     self.configure(env)
     daemon_cmd = format('/opt/cdap/kafka/bin/svc-kafka-server start')
-    no_op_test = format('ls {params.cdap_kafka_pid_file} >/dev/null 2>&1 && ps -p $(<{params.cdap_kafka_pid_file}) >/dev/null 2>&1')
+    no_op_test = format('ls {status_params.cdap_kafka_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_kafka_pid_file}) >/dev/null 2>&1')
     Execute( daemon_cmd,
              user=params.cdap_user,
              not_if=no_op_test

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -34,8 +34,7 @@ class Kafka(Script):
 
   def status(self, env):
     import status_params
-    env.set_params(status_params)
-    check_process_status(status_params.cdap_kafka_pid_file)
+    Execute('ls ' + status_params.cdap_kafka_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_kafka_pid_file + ') >/dev/null 2>&1')
 
   def configure(self, env):
     print 'Configure the CDAP Kafka Server'

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -36,9 +36,9 @@ class Master(Script):
     Execute('service cdap-master stop')
 
   def status(self, env):
-    import params
-    env.set_params(params)
-    check_process_status(params.cdap_master_pid_file)
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.cdap_master_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Master'

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -37,8 +37,7 @@ class Master(Script):
 
   def status(self, env):
     import status_params
-    env.set_params(status_params)
-    check_process_status(status_params.cdap_master_pid_file)
+    Execute('ls ' + status_params.cdap_master_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_master_pid_file + ') >/dev/null 2>&1')
 
   def configure(self, env):
     print 'Configure the CDAP Master'

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -17,13 +17,14 @@ class Master(Script):
   def start(self, env):
     print 'Start the CDAP Master'
     import params
+    import status_params
     env.set_params(params)
     self.configure(env)
     helpers.create_hdfs_dir(params.hdfs_namespace, params.hdfs_user, 755)
     # Hack to work around CDAP-1967
     self.remove_jackson(env)
     daemon_cmd = format('/opt/cdap/master/bin/svc-master start')
-    no_op_test = format('ls {params.cdap_master_pid_file} >/dev/null 2>&1 && ps -p $(<{params.cdap_master_pid_file}) >/dev/null 2>&1')
+    no_op_test = format('ls {status_params.cdap_master_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_master_pid_file}) >/dev/null 2>&1')
     Execute( daemon_cmd,
              user=params.cdap_user,
              not_if=no_op_test

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -71,7 +71,7 @@ kafka_hosts.sort()
 tmp_kafka_hosts = ''
 for i, val in enumerate(kafka_hosts):
   tmp_kafka_hosts += val + ':' + kafka_bind_port
-  if (i + 1) < len(tmp_kafka_hosts):
+  if i < len(tmp_kafka_hosts):
     tmp_kafka_hosts += ','
 cdap_kafka_brokers = tmp_kafka_hosts
 

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -84,8 +84,8 @@ cdap_router_host = router_hosts[0]
 # Get some of our hosts
 hive_metastore_host = config['clusterHostInfo']['hive_metastore_host']
 
-cdap_auth_pid_file = '/var/cdap/run/auth-server-' + cdap_user + '.pid'
-cdap_kafka_pid_file = '/var/cdap/run/kafka-server-' + cdap_user + '.pid'
-cdap_master_pid_file = '/var/cdap/run/master-' + cdap_user + '.pid'
-cdap_router_pid_file = '/var/cdap/run/router-' + cdap_user + '.pid'
-cdap_ui_pid_file = '/var/cdap/run/ui-' + cdap_user + '.pid'
+cdap_auth_pid_file = pid_dir + '/auth-server-' + cdap_user + '.pid'
+cdap_kafka_pid_file = pid_dir + '/kafka-server-' + cdap_user + '.pid'
+cdap_master_pid_file = pid_dir + '/master-' + cdap_user + '.pid'
+cdap_router_pid_file = pid_dir + '/router-' + cdap_user + '.pid'
+cdap_ui_pid_file = pid_dir + '/ui-' + cdap_user + '.pid'

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -83,9 +83,3 @@ cdap_router_host = router_hosts[0]
 
 # Get some of our hosts
 hive_metastore_host = config['clusterHostInfo']['hive_metastore_host']
-
-cdap_auth_pid_file = pid_dir + '/auth-server-' + cdap_user + '.pid'
-cdap_kafka_pid_file = pid_dir + '/kafka-server-' + cdap_user + '.pid'
-cdap_master_pid_file = pid_dir + '/master-' + cdap_user + '.pid'
-cdap_router_pid_file = pid_dir + '/router-' + cdap_user + '.pid'
-cdap_ui_pid_file = pid_dir + '/ui-' + cdap_user + '.pid'

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -34,8 +34,7 @@ class Router(Script):
 
   def status(self, env):
     import status_params
-    env.set_params(status_params)
-    check_process_status(status_params.cdap_router_pid_file)
+    Execute('ls ' + status_params.cdap_router_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_router_pid_file + ') >/dev/null 2>&1')
 
   def configure(self, env):
     print 'Configure the CDAP Router'

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -33,9 +33,9 @@ class Router(Script):
     Execute('service cdap-router stop')
 
   def status(self, env):
-    import params
-    env.set_params(params)
-    check_process_status(params.cdap_router_pid_file)
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.cdap_router_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Router'

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -17,10 +17,11 @@ class Router(Script):
   def start(self, env):
     print 'Start the CDAP Router'
     import params
+    import status_params
     env.set_params(params)
     self.configure(env)
     daemon_cmd = format('/opt/cdap/gateway/bin/svc-router start')
-    no_op_test = format('ls {params.cdap_router_pid_file} >/dev/null 2>&1 && ps -p $(<{params.cdap_router_pid_file}) >/dev/null 2>&1')
+    no_op_test = format('ls {status_params.cdap_router_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_router_pid_file}) >/dev/null 2>&1')
     Execute( daemon_cmd,
              user=params.cdap_user,
              not_if=no_op_test

--- a/package/scripts/status_params.py
+++ b/package/scripts/status_params.py
@@ -1,0 +1,13 @@
+from resource_management import *
+
+# config object that holds the configurations declared in the -config.xml file
+config = Script.get_config()
+
+cdap_user = config['configurations']['cdap-env']['cdap_user']
+pid_dir = config['configurations']['cdap-env']['cdap_pid_dir']
+
+cdap_auth_pid_file = pid_dir + '/auth-server-' + cdap_user + '.pid'
+cdap_kafka_pid_file = pid_dir + '/kafka-server-' + cdap_user + '.pid'
+cdap_master_pid_file = pid_dir + '/master-' + cdap_user + '.pid'
+cdap_router_pid_file = pid_dir + '/router-' + cdap_user + '.pid'
+cdap_ui_pid_file = pid_dir + '/ui-' + cdap_user + '.pid'

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -19,10 +19,11 @@ class UI(Script):
   def start(self, env):
     print 'Start the CDAP UI'
     import params
+    import status_params
     env.set_params(params)
     self.configure(env)
     daemon_cmd = format('/opt/cdap/ui/bin/svc-ui start')
-    no_op_test = format('ls {params.cdap_ui_pid_file} >/dev/null 2>&1 && ps -p $(<{params.cdap_ui_pid_file}) >/dev/null 2>&1')
+    no_op_test = format('ls {status_params.cdap_ui_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_ui_pid_file}) >/dev/null 2>&1')
     Execute( daemon_cmd,
              user=params.cdap_user,
              not_if=no_op_test

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -36,8 +36,7 @@ class UI(Script):
 
   def status(self, env):
     import status_params
-    env.set_params(status_params)
-    check_process_status(status_params.cdap_ui_pid_file)
+    Execute('ls ' + status_params.cdap_ui_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_ui_pid_file + ') >/dev/null 2>&1')
 
   def configure(self, env):
     print 'Configure the CDAP UI'

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -35,9 +35,9 @@ class UI(Script):
     Execute('service cdap-ui stop')
 
   def status(self, env):
-    import params
-    env.set_params(params)
-    check_process_status(params.cdap_ui_pid_file)
+    import status_params
+    env.set_params(status_params)
+    check_process_status(status_params.cdap_ui_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP UI'


### PR DESCRIPTION
This moves everything needed to run status commands to a new `status_params.py` script. This matches more closely with how upstream Ambari services are defined.

Bonus points:
<img width="481" alt="screen shot 2015-07-27 at 11 25 59 am" src="https://cloud.githubusercontent.com/assets/380021/8914132/4e3a4f9c-3452-11e5-8b11-33927a6a75e8.png">
