### PR TITLE
Set router.bind.port

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -654,6 +654,16 @@
   </property>
 
   <property>
+    <name>router.bind.port</name>
+    <value>{{cdap_router_port}}</name>
+  </property>
+
+  <property>
+    <name>router.server.port</name>
+    <value>${router.bind.port}</value>
+  </property>
+
+  <property>
     <name>dashboard.bind.port</name>
     <value>9999</value>
   </property>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -75,11 +75,16 @@ for i, val in enumerate(kafka_hosts):
     tmp_kafka_hosts += ','
 cdap_kafka_brokers = tmp_kafka_hosts
 
-### TODO: cdap_auth_server_hosts cdap_router_hosts cdap_ui_hosts
-
 router_hosts = config['clusterHostInfo']['cdap_router_hosts']
 router_hosts.sort()
 cdap_router_host = router_hosts[0]
 
 # Get some of our hosts
 hive_metastore_host = config['clusterHostInfo']['hive_metastore_host']
+hive_server_host = config['clusterHostInfo']['hive_server_host']
+if len(hive_server_host) > 0 && hive_server_host == cdap_router_host:
+  cdap_router_port = '11015'
+else:
+  cdap_router_port = '10000'
+
+### TODO: cdap_auth_server_hosts cdap_ui_hosts

--- a/package/scripts/service_check.py
+++ b/package/scripts/service_check.py
@@ -5,5 +5,9 @@ class CdapServiceCheck(Script):
     import params
     env.set_params(params)
 
+    status_url = 'http://' + cdap_router_host + ':' + cdap_router_port + '/v3/system/services'
+
+    ### TODO: do something useful here
+
 if __name__ == "__main__":
   CdapServiceCheck().execute()


### PR DESCRIPTION
Since it's possible to have the CDAP Router on the same machine as HiveServer2 and Ambari doesn't support the ability to list incompatible/conflicting services in a natural way, we're using a variable to control this port. The port will be `11015` when on the same host as `HiveServer2` and `10000` otherwise. This will need to be resolved in a better manner before HA is supported.
