### PR TITLE
Copy logback configs

### DIFF
--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -44,6 +44,12 @@ def cdap_config(name=None):
   )
 
   cleanup_opts()
+
+  # Copy logback.xml and logback-container.xml
+  for i in 'logback.xml', 'logback-container.xml':
+    no_op_test = 'ls ' + params.cdap_conf_dir + '/' + i + ' 2>/dev/null'
+    Execute('cp -f /etc/cdap/conf.dist/' + i + ' ' + params.cdap_conf_dir, not_if=no_op_test)
+
   Execute('update-alternatives --install /etc/cdap/conf cdap-conf ' + params.cdap_conf_dir + ' 50')
 
 def has_hive():


### PR DESCRIPTION
We copy logback.xml and logback-container.xml from the default
/etc/cdap/conf.dist but only if the files don't already exist.
Our entire service logging mechanism expects that we output logs
to STDOUT and those are captured and redirected to the logs,
rather than the logback.xml files being correctly setup to have
the services log to the correct files, directly.
