### PR TITLE
Remove version fetch until a safer version can be made

### DIFF
--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -53,6 +53,7 @@ def has_hive():
   else:
     return false
 
+### TODO: Update this with a safe version, as hdp-select doesn't exist on HDP < 2.2
 def get_hdp_version():
   try:
     command = 'hdp-select status hadoop-client'

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -15,7 +15,8 @@ distribution = platform.linux_distribution()[0].lower()
 hostname = config['hostname']
 java64_home = config['hostLevelParams']['java_home']
 user_group = config['configurations']['cluster-env']['user_group']
-hdp_version = helpers.get_hdp_version()
+### TODO: Add this back with a safe version of the function
+# hdp_version = helpers.get_hdp_version()
 
 if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'


### PR DESCRIPTION
This is currently preventing use on HDP versions prior to HDP 2.2...
