### PR TITLE
Updated Ambari support

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -60,6 +60,9 @@ JAVA=$JAVA_HOME/bin/java
 
 export HADOOP_HOME_WARN_SUPPRESS=1
 
+# Set native libs PATH
+export JAVA_LIBRARY_PATH=${JAVA_LIBRARY_PATH}:{{hadoop_lib_home}}/native/Linux-amd64-64:{{hadoop_lib_home}}/native
+
 export CDAP_HOME=/opt/cdap
 export CDAP_CONF={{cdap_conf_dir}}
 export LOG_DIR={{log_dir}}

--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -31,9 +31,42 @@
   </property>
 
   <property>
+    <name>cdap_kafka_heapsize</name>
+    <value>1024</value>
+    <description>CDAP Kafka Heap Size</description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>256</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+    </value-attributes>
+  </property>
+
+  <property>
     <name>cdap_master_heapsize</name>
     <value>1024</value>
     <description>CDAP Master Heap Size</description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>256</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+    </value-attributes>
+  </property>
+
+  <property>
+    <name>cdap_router_heapsize</name>
+    <value>1024</value>
+    <description>CDAP Router Heap Size</description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>256</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+    </value-attributes>
   </property>
 
   <property>
@@ -67,7 +100,9 @@ export CDAP_HOME=/opt/cdap
 export CDAP_CONF={{cdap_conf_dir}}
 export LOG_DIR={{log_dir}}
 export PID_DIR={{pid_dir}}
+export KAFKA_JAVA_HEAPMAX="-Xmx{{cdap_kafka_heapsize}}m"
 export MASTER_JAVA_HEAPMAX="-Xmx{{cdap_master_heapsize}}m"
+export ROUTER_JAVA_HEAPMAX="-Xmx{{cdap_router_heapsize}}m"
 export OPTS="${OPTS} -Dhdp.version=${HDP_VERSION:-{{hdp_version}}}"
     </value>
   </property>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -542,6 +542,11 @@
   </property>
 
   <property>
+    <name>router.bind.port</name>
+    <value>{{cdap_router_port}}</value>
+  </property>
+
+  <property>
     <name>router.server.port</name>
     <value>${router.bind.port}</value>
     <final>true</final>
@@ -553,6 +558,7 @@
     <description>Router listening port for webapp</description>
   </property>
 
+  <!-- Disable until SSL support
   <property>
     <name>router.ssl.bind.port</name>
     <value>10443</value>
@@ -570,6 +576,7 @@
     <value>20443</value>
     <description>Secure router listening port for webapp</description>
   </property>
+  -->
 
   <!-- New Metrics system settings -->
 
@@ -621,22 +628,70 @@
     <description>Number of netty server executor threads for metrics HTTP services</description>
   </property>
 
-  <!-- Unsorted -->
-
   <property>
-    <name>router.server.address</name>
-    <value>{{cdap_router_host}}</value>
+    <name>metrics.boss.threads</name>
+    <value>${http.service.boss.threads}</value>
+    <description>Number of netty server boss threads for metrics HTTP services</description>
   </property>
 
   <property>
-    <name>kafka.log.dir</name>
-    <value>/data/cdap-kafka/logs</value>
+    <name>metrics.worker.threads</name>
+    <value>${http.service.worker.threads}</value>
+    <description>Number of netty server worker threads for metrics HTTP services</description>
   </property>
 
   <property>
-    <name>kafka.bind.port</name>
-    <value>9092</value>
+    <name>metrics.num.instances</name>
+    <value>1</value>
   </property>
+
+  <property>
+    <name>metrics.max.instances</name>
+    <value>${master.service.max.instances}</value>
+  </property>
+
+  <property>
+    <name>metrics.num.cores</name>
+    <value>${master.service.num.cores}</value>
+  </property>
+
+  <property>
+    <name>metrics.memory.mb</name>
+    <value>${master.service.memory.mb}</value>
+  </property>
+
+  <!-- Metrics Processor Configuration -->
+
+  <property>
+    <name>metrics.processor.num.instances</name>
+    <value>1</value>
+    <description>Number of instances for Metrics Processor Service Apache Twill Runnable</description>
+  </property>
+
+  <property>
+    <name>metrics.processor.max.instances</name>
+    <value>${master.service.max.instances}</value>
+  </property>
+
+  <property>
+    <name>metrics.processor.num.cores</name>
+    <value>1</value>
+    <description>Number of cores for Metrics Processor Service Apache Twill Runnable</description>
+  </property>
+
+  <property>
+    <name>metrics.processor.memory.mb</name>
+    <value>512</value>
+    <description>Size of Memory in MB for Metrics Processor Service Apache Twill Runnable</description>
+  </property>
+
+  <property>
+    <name>metrics.dataset.hbase.stats.report.interval</name>
+    <value>60</value>
+    <description>Report interval for hbase stats, in seconds.</description>
+  </property>
+
+  <!-- Logging Configuration -->
 
   <property>
     <name>kafka.seed.brokers</name>
@@ -644,8 +699,15 @@
   </property>
 
   <property>
-    <name>kafka.default.replication.factor</name>
-    <value>1</value>
+    <name>log.publish.num.partitions</name>
+    <value>10</value>
+    <description>Number of Kafka partitions to publish the logs to</description>
+  </property>
+
+  <property>
+    <name>log.base.dir</name>
+    <value>/logs/avro</value>
+    <description>Base log directory</description>
   </property>
 
   <property>
@@ -654,18 +716,150 @@
   </property>
 
   <property>
-    <name>router.bind.port</name>
-    <value>{{cdap_router_port}}</name>
+    <name>log.cleanup.run.interval.mins</name>
+    <value>1440</value>
+    <description>Interval at which to run log cleanup</description>
   </property>
 
   <property>
-    <name>router.server.port</name>
-    <value>${router.bind.port}</value>
+    <name>log.saver.num.instances</name>
+    <value>1</value>
+    <description>Number of log saver instances to run in yarn</description>
+  </property>
+
+  <property>
+    <name>log.saver.max.instances</name>
+    <value>${master.service.max.instances}</value>
+  </property>
+
+  <property>
+    <name>log.saver.run.memory.megs</name>
+    <value>1024</value>
+    <description>Memory in MB for log saver instances to run in yarn</description>
+  </property>
+
+  <!-- Kafka Configuration -->
+
+  <property>
+    <name>kafka.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>Kafka server hostname to bind to</description>
+  </property>
+
+  <property>
+    <name>kafka.bind.port</name>
+    <value>9092</value>
+    <description>Kafka server port</description>
+  </property>
+
+  <property>
+    <name>kafka.num.partitions</name>
+    <value>10</value>
+    <description>Default number of partitions for a topic</description>
+  </property>
+
+  <property>
+    <name>kafka.log.dir</name>
+    <value>/data/cdap-kafka/logs</value>
+    <description>Directory to store Kafka logs</description>
+  </property>
+
+  <property>
+    <name>kafka.zookeeper.namespace</name>
+    <value>kafka</value>
+    <description>ZK namespace for Kafka</description>
+  </property>
+
+  <property>
+    <name>kafka.default.replication.factor</name>
+    <value>1</value>
+    <description>Kafka replication factor</description>
+  </property>
+
+  <!-- Web App Configuration -->
+
+  <property>
+    <name>dashboard.bind.address</name>
+    <value>0.0.0.0</value>
   </property>
 
   <property>
     <name>dashboard.bind.port</name>
     <value>9999</value>
+  </property>
+
+  <!-- Disable until SSL support
+  <property>
+    <name>dashboard.ssl.bind.port</name>
+    <value>9443</value>
+  </property>
+
+  <property>
+    <name>dashboard.ssl.disable.cert.check</name>
+    <value>false</value>
+  </property>
+  -->
+
+  <property>
+    <name>router.server.address</name>
+    <value>{{cdap_router_host}}</value>
+  </property>
+
+  <!-- Explore Configuration -->
+
+  <property>
+    <name>explore.enabled</name>
+    <value>false</value>
+    <description>Whether ad-hoc SQL queries are enabled</description>
+  </property>
+
+  <property>
+    <name>explore.writes.enabled</name>
+    <value>true</value>
+    <description>Whether writing to a table through ad-hoc SQL queries is enabled</description>
+  </property>
+
+  <property>
+    <name>explore.start.on.demand</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>explore.executor.container.instances</name>
+    <value>1</value>
+    <description>Number of explore executor instances</description>
+  </property>
+
+  <property>
+    <name>explore.executor.max.instances</name>
+    <value>1</value>
+    <description>Maximum number of explore executor instances</description>
+  </property>
+
+  <property>
+    <name>explore.active.operation.timeout.secs</name>
+    <value>86400</value>
+    <description>Timeout value in seconds for a SQL operation whose result is not fetched completely</description>
+  </property>
+
+  <property>
+    <name>explore.inactive.operation.timeout.secs</name>
+    <value>3600</value>
+    <description>Timeout value in seconds for a SQL operation which does not have any more results to be fetched</description>
+  </property>
+
+  <property>
+    <name>explore.cleanup.job.schedule.secs</name>
+    <value>60</value>
+    <description>Time in secs to schedule clean up job to timeout operations</description>
+  </property>
+
+  <!-- Notification System Settings -->
+
+  <property>
+    <name>notification.transport.system</name>
+    <value>kafka</value>
+    <description>Transport system used by the Notification system - can be kafka/stream</description>
   </property>
 
 </configuration>

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -59,21 +59,15 @@ def has_hive():
   else:
     return false
 
-### TODO: Update this with a safe version, as hdp-select doesn't exist on HDP < 2.2
 def get_hdp_version():
-  try:
-    command = 'hdp-select status hadoop-client'
-    return_code, hdp_output = shell.call(command, timeout=20)
-  except Exception, e:
-    Logger.error(str(e))
-    raise Fail('Unable to execute hdp-select command to retrieve the version.')
+  command = 'hadoop version | head -n 1 | cut -d. -f4-'
+  return_code, hdp_output = shell.call(command, timeout=20)
 
   if return_code != 0:
     raise Fail(
       'Unable to determine the current version because of a non-zero return code of {0}'.format(str(return_code)))
 
-  hdp_version = re.sub('hadoop-client - ', '', hdp_output)
-  hdp_version = hdp_version.rstrip()
+  hdp_version = hdp_output.rstrip()
   match = re.match('[0-9]+.[0-9]+.[0-9]+.[0-9]+-[0-9]+', hdp_version)
 
   if match is None:

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -43,7 +43,7 @@ def cdap_config(name=None):
        content=InlineTemplate(params.cdap_env_sh_template)
   )
 
-  cleanup_opts()
+  cleanup_opts(name)
 
   # Copy logback.xml and logback-container.xml
   for i in 'logback.xml', 'logback-container.xml':
@@ -75,5 +75,7 @@ def get_hdp_version():
 
   return hdp_version
 
-def cleanup_opts():
-  Execute('sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/*/bin/service')
+def cleanup_opts(name):
+  command = 'sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + name + '/bin/service'
+  return_code, output = shell.call(command, timeout=20)
+  # Execute('sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + name + '/bin/service', not_if=no_op_test)

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -44,6 +44,12 @@ def cdap_config(name=None):
   )
 
   cleanup_opts()
+
+  # Copy logback.xml and logback-container.xml
+  for i in 'logback.xml', 'logback-container.xml':
+    no_op_test = 'ls ' + params.cdap_conf_dir + '/' + i + ' 2>/dev/null'
+    Execute('cp -f /etc/cdap/conf.dist/' + i + ' ' + params.cdap_conf_dir, not_if=no_op_test)
+
   Execute('update-alternatives --install /etc/cdap/conf cdap-conf ' + params.cdap_conf_dir + ' 50')
 
 def has_hive():

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -67,14 +67,16 @@ def has_hive():
     return false
 
 def get_hdp_version():
-  command = 'hadoop version | head -n 1 | cut -d. -f4-'
+  command = 'hadoop version'
   return_code, hdp_output = shell.call(command, timeout=20)
 
   if return_code != 0:
     raise Fail(
       'Unable to determine the current version because of a non-zero return code of {0}'.format(str(return_code)))
 
-  hdp_version = hdp_output.rstrip()
+  line = hdp_output.rstrip().split('\n')[0]
+  arr = line.split('.')
+  hdp_version = "%s.%s.%s.%s" % (arr[3], arr[4], arr[5], arr[6])
   match = re.match('[0-9]+.[0-9]+.[0-9]+.[0-9]+-[0-9]+', hdp_version)
   if match is None:
     raise Fail('Failed to get extracted version')

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -85,7 +85,7 @@ def get_hadoop_lib():
   v = self.get_hdp_version()
   arr = v.split('.')
   maj_min = float("%s.%s" % (arr[0], arr[1]))
-  if maj_min > 2.2:
+  if maj_min >= 2.2:
     hadoop_lib = "/usr/hdp/%s/hadoop/lib" % (v)
   else:
     hadoop_lib = '/usr/lib/hadoop/lib'

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -71,8 +71,7 @@ def get_hdp_version():
   return_code, hdp_output = shell.call(command, timeout=20)
 
   if return_code != 0:
-    raise Fail(
-      'Unable to determine the current version because of a non-zero return code of {0}'.format(str(return_code)))
+    raise Fail("Unable to determine the current hadoop version: %s" % (hdp_output))
 
   line = hdp_output.rstrip().split('\n')[0]
   arr = line.split('.')

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -76,11 +76,19 @@ def get_hdp_version():
 
   hdp_version = hdp_output.rstrip()
   match = re.match('[0-9]+.[0-9]+.[0-9]+.[0-9]+-[0-9]+', hdp_version)
-
   if match is None:
     raise Fail('Failed to get extracted version')
-
   return hdp_version
+
+def get_hadoop_lib():
+  v = self.get_hdp_version()
+  a, b, c, d = v.split('.')
+  majmin = float(a + '.' + b)
+  if maj_min > 2.2:
+    hadoop_lib = '/usr/hdp/' + hdp_version + '/hadoop/lib'
+  else:
+    hadoop_lib = '/usr/lib/hadoop/lib'
+  return hadoop_lib
 
 def cleanup_opts(dirname):
   command = 'sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + dirname + '/bin/service'

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -43,7 +43,14 @@ def cdap_config(name=None):
        content=InlineTemplate(params.cdap_env_sh_template)
   )
 
-  cleanup_opts(name)
+  if name == 'auth':
+    dirname = 'security'
+  elif name == 'router':
+    dirname = 'gateway'
+  else:
+    dirname = name
+
+  cleanup_opts(dirname)
 
   # Copy logback.xml and logback-container.xml
   for i in 'logback.xml', 'logback-container.xml':
@@ -75,7 +82,7 @@ def get_hdp_version():
 
   return hdp_version
 
-def cleanup_opts(name):
-  command = 'sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + name + '/bin/service'
+def cleanup_opts(dirname):
+  command = 'sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + dirname + '/bin/service'
   return_code, output = shell.call(command, timeout=20)
-  # Execute('sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + name + '/bin/service', not_if=no_op_test)
+  # Execute('sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + dirname + '/bin/service', not_if=no_op_test)

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -2,18 +2,18 @@ from resource_management import *
 import os
 
 def create_hdfs_dir(path, owner, perms):
-  Execute('hadoop fs -mkdir -p '+path, user='hdfs')
-  Execute('hadoop fs -chown ' + owner + ' ' + path, user='hdfs')
-  Execute('hadoop fs -chmod ' + str(perms) + ' ' + path, user='hdfs')
+  Execute("hadoop fs -mkdir -p %s" % (path), user='hdfs')
+  Execute("hadoop fs -chown %s %s" % (owner, path), user='hdfs')
+  Execute("hadoop fs -chmod %s %s" % (str(perms), path), user='hdfs')
 
 def package(name):
   import params
-  Execute(params.package_mgr + ' install -y ' + name, user='root')
+  Execute("%s install -y %s" % (params.package_mgr, name), user='root')
 
 def add_repo(source, dest):
   import params
   if not os.path.isfile(dest + params.repo_file):
-    Execute('cp ' + source + ' ' + dest)
+    Execute("cp %s %s" % (source, dest)
     Execute(params.key_cmd)
     Execute(params.cache_cmd)
 
@@ -31,7 +31,7 @@ def cdap_config(name=None):
             recursive = True
   )
 
-  XmlConfig("cdap-site.xml",
+  XmlConfig('cdap-site.xml',
             conf_dir = params.cdap_conf_dir,
             configurations = params.config['configurations']['cdap-site'],
             owner = params.cdap_user,
@@ -54,10 +54,10 @@ def cdap_config(name=None):
 
   # Copy logback.xml and logback-container.xml
   for i in 'logback.xml', 'logback-container.xml':
-    no_op_test = 'ls ' + params.cdap_conf_dir + '/' + i + ' 2>/dev/null'
-    Execute('cp -f /etc/cdap/conf.dist/' + i + ' ' + params.cdap_conf_dir, not_if=no_op_test)
+    no_op_test = "ls %s/%s 2>/dev/null" % (params.cdap_conf_dir, i)
+    Execute("cp -f /etc/cdap/conf.dist/%s %s" % (i, params.cdap_conf_dir), not_if=no_op_test)
 
-  Execute('update-alternatives --install /etc/cdap/conf cdap-conf ' + params.cdap_conf_dir + ' 50')
+  Execute("update-alternatives --install /etc/cdap/conf cdap-conf %s 50" % (params.cdap_conf_dir)
 
 def has_hive():
   import params
@@ -83,15 +83,15 @@ def get_hdp_version():
 
 def get_hadoop_lib():
   v = self.get_hdp_version()
-  a, b, c, d = v.split('.')
-  maj_min = float(a + '.' + b)
+  arr = v.split('.')
+  maj_min = float("%s.%s" % (arr[0], arr[1]))
   if maj_min > 2.2:
-    hadoop_lib = '/usr/hdp/' + v + '/hadoop/lib'
+    hadoop_lib = "/usr/hdp/%s/hadoop/lib" % (v)
   else:
     hadoop_lib = '/usr/lib/hadoop/lib'
   return hadoop_lib
 
 def cleanup_opts(dirname):
-  command = 'sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + dirname + '/bin/service'
+  command = "sed -i 's/\"$OPTS\"/$OPTS/g' /opt/cdap/%s/bin/service" % (dirname)
+  # We ignore errors here, in case we are called before package installation
   return_code, output = shell.call(command, timeout=20)
-  # Execute('sed -i \'s/"$OPTS"/$OPTS/g\' /opt/cdap/' + dirname + '/bin/service', not_if=no_op_test)

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -94,4 +94,4 @@ def get_hadoop_lib():
 def cleanup_opts(dirname):
   command = "sed -i 's/\"$OPTS\"/$OPTS/g' /opt/cdap/%s/bin/service" % (dirname)
   # We ignore errors here, in case we are called before package installation
-  return_code, output = shell.call(command, timeout=20)
+  shell.call(command, timeout=20)

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -83,9 +83,9 @@ def get_hdp_version():
 def get_hadoop_lib():
   v = self.get_hdp_version()
   a, b, c, d = v.split('.')
-  majmin = float(a + '.' + b)
+  maj_min = float(a + '.' + b)
   if maj_min > 2.2:
-    hadoop_lib = '/usr/hdp/' + hdp_version + '/hadoop/lib'
+    hadoop_lib = '/usr/hdp/' + v + '/hadoop/lib'
   else:
     hadoop_lib = '/usr/lib/hadoop/lib'
   return hadoop_lib

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -35,7 +35,7 @@ class Auth(Script):
 
   def status(self, env):
     import status_params
-    Execute('ls ' + status_params.cdap_auth_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_auth_pid_file + ') >/dev/null 2>&1')
+    check_process_status(status_params.cdap_auth_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Auth Server'

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -6,13 +6,13 @@ class Auth(Script):
   def install(self, env):
     print 'Install the CDAP Auth Server'
     import params
-    self.configure(env)
     # Add repository file
     helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
     # Install any global packages
     self.install_packages(env)
     # Install package
     helpers.package('cdap-security')
+    self.configure(env)
 
   def start(self, env):
     print 'Start the CDAP Auth Server'

--- a/package/scripts/cli.py
+++ b/package/scripts/cli.py
@@ -4,12 +4,20 @@ from resource_management import *
 class CLI(Script):
   def install(self, env):
     print 'Install the CDAP CLI'
+    import params
+    # Add repository file
+    helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
+    # Install package
+    helpers.package('cdap-cli')
+    self.configure(env)
 
   def configure(self, env):
     print 'Configure the CDAP CLI'
     import params
     env.set_params(params)
-    helpers.cdap_config('client')
+    helpers.cdap_config('cli')
 
   def status(self, env):
     raise ClientComponentHasNoStatus()

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -35,7 +35,7 @@ class Kafka(Script):
 
   def status(self, env):
     import status_params
-    Execute('ls ' + status_params.cdap_kafka_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_kafka_pid_file + ') >/dev/null 2>&1')
+    check_process_status(status_params.cdap_kafka_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Kafka Server'

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -6,13 +6,13 @@ class Kafka(Script):
   def install(self, env):
     print 'Install the CDAP Kafka Server'
     import params
-    self.configure(env)
     # Add repository file
     helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
     # Install any global packages
     self.install_packages(env)
     # Install package
     helpers.package('cdap-kafka')
+    self.configure(env)
 
   def start(self, env):
     print 'Start the CDAP Kafka Server'

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -6,13 +6,13 @@ class Master(Script):
   def install(self, env):
     print 'Install the CDAP Master'
     import params
-    # Install any global packages
-    self.install_packages(env)
-    self.configure(env)
     # Add repository file
     helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
+    # Install any global packages
+    self.install_packages(env)
     # Install package
     helpers.package('cdap-master')
+    self.configure(env)
 
   def start(self, env):
     print 'Start the CDAP Master'

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -38,7 +38,7 @@ class Master(Script):
 
   def status(self, env):
     import status_params
-    Execute('ls ' + status_params.cdap_master_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_master_pid_file + ') >/dev/null 2>&1')
+    check_process_status(status_params.cdap_master_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Master'

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -16,9 +16,8 @@ hostname = config['hostname']
 java64_home = config['hostLevelParams']['java_home']
 user_group = config['configurations']['cluster-env']['user_group']
 
-### TODO: this only works on HDP 2.2+
 hdp_version = helpers.get_hdp_version()
-hadoop_lib_home = '/usr/hdp/' + hdp_version + '/hadoop/lib'
+hadoop_lib_home = helpers.get_hadoop_lib()
 
 if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -15,8 +15,10 @@ distribution = platform.linux_distribution()[0].lower()
 hostname = config['hostname']
 java64_home = config['hostLevelParams']['java_home']
 user_group = config['configurations']['cluster-env']['user_group']
-### TODO: Add this back with a safe version of the function
-# hdp_version = helpers.get_hdp_version()
+
+### TODO: this only works on HDP 2.2+
+hdp_version = helpers.get_hdp_version()
+hadoop_lib_home = '/usr/hdp/' + hdp_version + '/hadoop/lib'
 
 if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -23,13 +23,13 @@ if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'
   repo_file = 'cdap-3.0.repo'
   package_mgr = 'yum'
-  key_cmd = 'rpm --import ' + files_dir + 'pubkey.gpg'
+  key_cmd = "rpm --import %s/pubkey.gpg" % (files_dir)
   cache_cmd = 'yum makecache'
 else :
   os_repo_dir = '/etc/apt/sources.list.d/'
   repo_file = 'cdap-3.0.list'
   package_mgr = 'apt-get'
-  key_cmd = 'apt-key add ' + files_dir + 'pubkey.gpg'
+  key_cmd = "apt-key add %s/pubkey.gpg" % (files_dir)
   cache_cmd = 'apt-get update'
 
 cdap_user = config['configurations']['cdap-env']['cdap_user']

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -36,7 +36,9 @@ else :
 cdap_user = config['configurations']['cdap-env']['cdap_user']
 log_dir = config['configurations']['cdap-env']['cdap_log_dir']
 pid_dir = config['configurations']['cdap-env']['cdap_pid_dir']
+cdap_kafka_heapsize = config['configurations']['cdap-env']['cdap_kafka_heapsize']
 cdap_master_heapsize = config['configurations']['cdap-env']['cdap_master_heapsize']
+cdap_router_heapsize = config['configurations']['cdap-env']['cdap_router_heapsize']
 
 etc_prefix_dir = "/etc/cdap"
 cdap_conf_dir = "/etc/cdap/conf.ambari"

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -6,13 +6,13 @@ class Router(Script):
   def install(self, env):
     print 'Install the CDAP Router'
     import params
-    self.configure(env)
     # Add repository file
     helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
     # Install any global packages
     self.install_packages(env)
     # Install package
     helpers.package('cdap-gateway')
+    self.configure(env)
 
   def start(self, env):
     print 'Start the CDAP Router'

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -35,7 +35,7 @@ class Router(Script):
 
   def status(self, env):
     import status_params
-    Execute('ls ' + status_params.cdap_router_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_router_pid_file + ') >/dev/null 2>&1')
+    check_process_status(status_params.cdap_router_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP Router'

--- a/package/scripts/service_check.py
+++ b/package/scripts/service_check.py
@@ -5,7 +5,7 @@ class CdapServiceCheck(Script):
     import params
     env.set_params(params)
 
-    status_url = 'http://' + cdap_router_host + ':' + cdap_router_port + '/v3/system/services'
+    status_url = 'http://' + params.cdap_router_host + ':' + params.cdap_router_port + '/v3/system/services'
 
     ### TODO: do something useful here
 

--- a/package/scripts/service_check.py
+++ b/package/scripts/service_check.py
@@ -5,7 +5,7 @@ class CdapServiceCheck(Script):
     import params
     env.set_params(params)
 
-    status_url = 'http://' + params.cdap_router_host + ':' + params.cdap_router_port + '/v3/system/services'
+    status_url = "http://%s:%s/v3/system/services" % (params.cdap_router_host, params.cdap_router_port)
 
     ### TODO: do something useful here
 

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -37,7 +37,7 @@ class UI(Script):
 
   def status(self, env):
     import status_params
-    Execute('ls ' + status_params.cdap_ui_pid_file + ' >/dev/null 2>&1 && ps -p $(<' + status_params.cdap_ui_pid_file + ') >/dev/null 2>&1')
+    check_process_status(status_params.cdap_ui_pid_file)
 
   def configure(self, env):
     print 'Configure the CDAP UI'

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -6,13 +6,13 @@ class UI(Script):
   def install(self, env):
     print 'Install the CDAP UI'
     import params
-    self.configure(env)
     # Add repository file
     helpers.add_repo(params.files_dir + params.repo_file, params.os_repo_dir)
     # Install any global packages
     self.install_packages(env)
     # Install package
     helpers.package('cdap-ui')
+    self.configure(env)
     # TODO: make sure this is available
     helpers.package('nodejs')
 


### PR DESCRIPTION
With this PR, we are able to support versions of HDP prior to HDP 2.2, which wasn't possible before.

This PR replaces the following pull requests, which have been closed: #23 #24 #25 #26 #28 
- [x] Support `cdap-default.xml` options as of 2015-07-27 except SSL options
- [x] Copy `logback.xml` and `logback-container.xml` from CDAP's `conf.dist` if it does not already exist
- [x] Load Hadoop Native libraries
- [x] Support setting Router/Master/Kafka heap sizes
- [x] Get version from parsing `hadoop version` rather than relying on the HDP 2.2+ only `hdp-select`
- [x] Make cleanup_opts safe to execute when packages aren't installed
- [x] Install CDAP CLI package
- [x] Configure after install, for `cleanup_opts` and logback copying
- [x] Scope variables correctly for `service_check.py`
- [x] Set `hadoop_lib_home` using updated version parsing
