### PR TITLE
Develop should use latest released CDAP

### DIFF
--- a/package/files/cdap-3.0.list
+++ b/package/files/cdap-3.0.list
@@ -1,1 +1,0 @@
-deb [ arch=amd64 ] http://repository.cask.co/ubuntu/precise/amd64/cdap/3.0 precise cdap

--- a/package/files/cdap-3.0.repo
+++ b/package/files/cdap-3.0.repo
@@ -1,5 +1,0 @@
-[CDAP-3.0]
-name=Cask Data Application Platform Packages
-baseurl=http://repository.cask.co/centos/6/x86_64/cdap/3.0
-enabled=1
-gpgcheck=1

--- a/package/files/cdap-3.1.list
+++ b/package/files/cdap-3.1.list
@@ -1,0 +1,1 @@
+deb [ arch=amd64 ] http://repository.cask.co/ubuntu/precise/amd64/cdap/3.1 precise cdap

--- a/package/files/cdap-3.1.repo
+++ b/package/files/cdap-3.1.repo
@@ -1,0 +1,5 @@
+[CDAP-3.1]
+name=Cask Data Application Platform Packages
+baseurl=http://repository.cask.co/centos/6/x86_64/cdap/3.1
+enabled=1
+gpgcheck=1

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -21,13 +21,13 @@ hadoop_lib_home = helpers.get_hadoop_lib()
 
 if distribution in ['centos', 'redhat'] :
   os_repo_dir = '/etc/yum.repos.d/'
-  repo_file = 'cdap-3.0.repo'
+  repo_file = 'cdap-3.1.repo'
   package_mgr = 'yum'
   key_cmd = "rpm --import %s/pubkey.gpg" % (files_dir)
   cache_cmd = 'yum makecache'
 else :
   os_repo_dir = '/etc/apt/sources.list.d/'
-  repo_file = 'cdap-3.0.list'
+  repo_file = 'cdap-3.1.list'
   package_mgr = 'apt-get'
   key_cmd = "apt-key add %s/pubkey.gpg" % (files_dir)
   cache_cmd = 'apt-get update'


### PR DESCRIPTION
This just merges release/3.1 back to develop, so develop will be using the latest released version of CDAP.
