### PR TITLE
Implement fix for CDAP-3786

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -489,7 +489,7 @@
 
   <property>
     <name>app.program.jvm.opts</name>
-    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=${hdp.version}</value>
+    <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=${hdp.version} -Dspark.yarn.am.extraJavaOptions=-Dhdp.version=${hdp.version}</value>
     <description>Java options for all program containers</description>
   </property>
 


### PR DESCRIPTION
This is the same fix as in caskdata/cdap#4106 but applied to the Ambari service definition.
