### PR TITLE
Set UTF-8 encoding

### DIFF
--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/cli.py
+++ b/package/scripts/cli.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/service_check.py
+++ b/package/scripts/service_check.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/status_params.py
+++ b/package/scripts/status_params.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -1,3 +1,4 @@
+# coding=utf8
 # Copyright © 2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not


### PR DESCRIPTION
This is per https://www.python.org/dev/peps/pep-0263/ and otherwise
causes Ambari to fail with syntax errors in Ambari 2.1 (at least).
