### PR TITLE
CDAP-3961 Install cdap-hbase-compat-1.1 manually

### DIFF
--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -29,6 +29,8 @@ class Master(Script):
         )
         # Install any global packages
         self.install_packages(env)
+        # Workaround for CDAP-3961
+        helpers.package('cdap-hbase-compat-1.1')
         # Install package
         helpers.package('cdap-master')
         self.configure(env)


### PR DESCRIPTION
This resolves issues with missing classes and works around a missing dependency in the `cdap-master-3.2.0` package.
