### PR TITLE
Create HDFS home directory for hdfs.user

### DIFF
--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -40,6 +40,8 @@ class Master(Script):
         env.set_params(params)
         self.configure(env)
         helpers.create_hdfs_dir(params.hdfs_namespace, params.hdfs_user, 755)
+        # Create user's HDFS home
+        helpers.create_hdfs_dir('/user/' + params.hdfs_user, params.hdfs_user, 755)
         # Hack to work around CDAP-1967
         self.remove_jackson(env)
         daemon_cmd = format('/opt/cdap/master/bin/svc-master start')


### PR DESCRIPTION
This needs to be done prior to CDAP starting to ensure `hive -e 'set -v'` can run as the correct user.
