### PR TITLE
Enable explore by default

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -863,7 +863,7 @@
 
   <property>
     <name>explore.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <description>Whether ad-hoc SQL queries are enabled</description>
   </property>
 

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -227,6 +227,7 @@
         <service>HDFS</service>
         <service>YARN</service>
         <service>ZOOKEEPER</service>
+        <service>HIVE</service>
       </requiredServices>
 
       <!-- names for config files (under configuration dir) -->


### PR DESCRIPTION
Enable explore by default in ambari configuration.

Related PR in CDAP repo:
https://github.com/caskdata/cdap/pull/4859
