### PR TITLE
update logic to accomodate centos7 reporting distribution as "CentOS …

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -34,7 +34,7 @@ user_group = config['configurations']['cluster-env']['user_group']
 hdp_version = helpers.get_hdp_version()
 hadoop_lib_home = helpers.get_hadoop_lib()
 
-if distribution in ['centos', 'redhat']:
+if distribution.startswith('centos') or distribution.startswith('redhat'):
     os_repo_dir = '/etc/yum.repos.d/'
     repo_file = 'cdap-3.2.repo'
     package_mgr = 'yum'


### PR DESCRIPTION
…Linux"

CentOS7 reports linux_distribution as: `('CentOS Linux', '7.0.1406', 'Core')`.  This updates the platform detection logic to accomodate `CentOS Linux`
