### PR TITLE
Remove Node.js for caskdata/cdap#5522

### DIFF
--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright © 2015 Cask Data, Inc.
+# Copyright © 2015-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -32,8 +32,6 @@ class UI(Script):
         # Install package
         helpers.package('cdap-ui')
         self.configure(env)
-        # TODO: make sure this is available
-        helpers.package('nodejs')
 
     def start(self, env):
         print 'Start the CDAP UI'


### PR DESCRIPTION
We no longer need to provide the `Node.js` packaging as it is included in CDAP RPM and DEB packaging in CDAP 3.4+
