### PR TITLE
CDAP-3957 Support custom CDAP repositories

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -19,6 +19,26 @@
 <configuration>
 
   <property>
+    <name>apt_repo_url</name>
+    <value>http://repository.cask.co/ubuntu/precise/amd64/cdap/3.4</value>
+    <description>
+      URL to an APT repository hosting this version of CDAP. Defaults to
+      the public Cask repository address
+    </description>
+    <display-name>APT Repository URL</display-name>
+  </property>
+
+  <property>
+    <name>yum_repo_url</name>
+    <value>http://repository.cask.co/centos/6/x86_64/cdap/3.4</value>
+    <description>
+      URL to an YUM repository hosting this version of CDAP. Defaults to
+      the public Cask repository address
+    </description>
+    <display-name>YUM Repository URL</display-name>
+  </property>
+
+  <property>
     <name>cdap_log_dir</name>
     <value>/var/log/cdap</value>
     <description>Log directory for CDAP</description>

--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -32,7 +32,7 @@
     <name>yum_repo_url</name>
     <value>http://repository.cask.co/centos/6/x86_64/cdap/3.4</value>
     <description>
-      URL to an YUM repository hosting this version of CDAP. Defaults to
+      URL to a YUM repository hosting this version of CDAP. Defaults to
       the public Cask repository address
     </description>
     <display-name>YUM Repository URL</display-name>

--- a/package/files/cdap-3.4.list
+++ b/package/files/cdap-3.4.list
@@ -1,1 +1,1 @@
-deb [ arch=amd64 ] http://repository.cask.co/ubuntu/precise/amd64/cdap/3.4 precise cdap
+deb [ arch=amd64 ] REPO_URL precise cdap

--- a/package/files/cdap-3.4.repo
+++ b/package/files/cdap-3.4.repo
@@ -1,5 +1,5 @@
 [CDAP-3.4]
 name=Cask Data Application Platform Packages
-baseurl=http://repository.cask.co/centos/6/x86_64/cdap/3.4
+baseurl=REPO_URL
 enabled=1
 gpgcheck=1

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -31,10 +31,10 @@ def package(name):
 
 def add_repo(source, dest):
     import params
-    if not os.path.isfile(dest + params.repo_file):
-        Execute("cp %s %s" % (source, dest))
-        Execute(params.key_cmd)
-        Execute(params.cache_cmd)
+    dest_file = dest + params.repo_file
+    Execute("sed -e 's#REPO_URL#%s#' %s > %s" % (params.repo_url, source, dest_file))
+    Execute(params.key_cmd)
+    Execute(params.cache_cmd)
 
 
 def cdap_config(name=None):

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -40,12 +40,14 @@ if distribution.startswith('centos') or distribution.startswith('redhat'):
     package_mgr = 'yum'
     key_cmd = "rpm --import %s/pubkey.gpg" % (files_dir)
     cache_cmd = 'yum makecache'
+    repo_url = config['configurations']['cdap-env']['yum_repo_url']
 else:
     os_repo_dir = '/etc/apt/sources.list.d/'
     repo_file = 'cdap-3.4.list'
     package_mgr = 'apt-get'
     key_cmd = "apt-key add %s/pubkey.gpg" % (files_dir)
     cache_cmd = 'apt-get update'
+    repo_url = config['configurations']['cdap-env']['apt_repo_url']
 
 cdap_user = config['configurations']['cdap-env']['cdap_user']
 log_dir = config['configurations']['cdap-env']['cdap_log_dir']


### PR DESCRIPTION
This allows setting the repository where the CDAP packages will be sourced. This allows someone to mirror the CDAP repository/packages without relying on the public CDAP mirrors. This is especially important for clusters without access to the Internet.

<img width="771" alt="screen shot 2016-05-11 at 4 25 07 pm" src="https://cloud.githubusercontent.com/assets/380021/15195353/7e9782be-1795-11e6-8781-9d6b2db8ddc9.png">
