### PR TITLE
Set router.bind.port to 11015

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -761,7 +761,7 @@
 
   <property>
     <name>router.bind.port</name>
-    <value>{{cdap_router_port}}</value>
+    <value>11015</value>
     <description>
       CDAP Router service bind port
     </description>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -100,12 +100,4 @@ router_hosts = config['clusterHostInfo']['cdap_router_hosts']
 router_hosts.sort()
 cdap_router_host = router_hosts[0]
 
-# Get some of our hosts
-hive_metastore_host = config['clusterHostInfo']['hive_metastore_host']
-hive_server_host = config['clusterHostInfo']['hive_server_host']
-if len(hive_server_host) > 0 and hive_server_host == cdap_router_host:
-    cdap_router_port = '11015'
-else:
-    cdap_router_port = '10000'
-
 # TODO: cdap_auth_server_hosts cdap_ui_hosts


### PR DESCRIPTION
This was previously dependent on whether or not HiveServer2 was on the same host. This made the port host-specific, which is a bad user experience. Also, if the cluster had 2 CDAP Routers, but only 1 HiveServer2, it would be possible to have the two CDAP Routers running on different ports. This would be extremely confusing to a user.

There's some information about this in [CDAP-1696](https://issues.cask.co/browse/CDAP-1696)
