### PR TITLE
Improve display of properties with Ambari-specific tags

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2015-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -26,6 +26,9 @@
       the public Cask repository address
     </description>
     <display-name>APT Repository URL</display-name>
+    <value-attributes>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -36,30 +39,43 @@
       the public Cask repository address
     </description>
     <display-name>YUM Repository URL</display-name>
+    <value-attributes>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
     <name>cdap_log_dir</name>
     <value>/var/log/cdap</value>
     <description>Log directory for CDAP</description>
+    <display-name>Log directory for CDAP</display-name>
+    <value-attributes>
+      <type>directories</type>
+    </value-attributes>
   </property>
 
   <property>
     <name>cdap_pid_dir</name>
     <value>/var/run/cdap</value>
     <description>PID directory for CDAP</description>
+    <display-name>PID directory for CDAP</display-name>
+    <value-attributes>
+      <type>directories</type>
+    </value-attributes>
   </property>
 
   <property>
     <name>cdap_kafka_heapsize</name>
     <value>1024</value>
     <description>CDAP Kafka Heap Size</description>
+    <display-name>CDAP Kafka Heap Size</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
+      <overridable>false</overridable>
     </value-attributes>
   </property>
 
@@ -67,12 +83,14 @@
     <name>cdap_master_heapsize</name>
     <value>1024</value>
     <description>CDAP Master Heap Size</description>
+    <display-name>CDAP Master Heap Size</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
+      <overridable>false</overridable>
     </value-attributes>
   </property>
 
@@ -80,12 +98,14 @@
     <name>cdap_router_heapsize</name>
     <value>1024</value>
     <description>CDAP Router Heap Size</description>
+    <display-name>CDAP Router Heap Size</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
+      <overridable>false</overridable>
     </value-attributes>
   </property>
 
@@ -94,6 +114,7 @@
     <value>cdap</value>
     <property-type>USER</property-type>
     <description>CDAP User Name</description>
+    <display-name>CDAP User Name</display-name>
   </property>
 
   <!-- cdap-env.sh -->
@@ -128,5 +149,9 @@ export ROUTER_JAVA_HEAPMAX="-Xmx{{cdap_router_heapsize}}m"
 export OPTS="${OPTS} -Dhdp.version=${HDP_VERSION:-{{hdp_version}}}"
 export TEZ_HOME="/usr/hdp/{{hdp_version}}/tez"
 export TEZ_CONF_DIR="/etc/tez/conf"</value>
+    <display-name>Contents of cdap-env.sh</display-name>
+    <value-attributes>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 </configuration>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2015 Cask Data, Inc.
+  Copyright © 2015-2016 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -65,6 +65,11 @@
       settings. If any checks fail, the CDAP Master will fail to start instead of waiting for the problem to be fixed.
       This setting only affects Distributed CDAP. It does not apply to Standalone CDAP.
     </description>
+    <display-name>Master startup checks</display-name>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -200,6 +205,14 @@
     <name>master.service.num.cores</name>
     <value>2</value>
     <description>Number of cores for Master Service instance</description>
+    <display-name>CDAP Master YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -208,6 +221,15 @@
     <description>
       Size of memory in megabytes for Master Service instance
     </description>
+    <display-name>CDAP Master YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -375,6 +397,14 @@
       Number of virtual core for the YARN container that runs the stream
       handler
     </description>
+    <display-name>Stream YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -384,6 +414,15 @@
       Amount of memory in megabytes for the YARN container that runs the
       stream handler
     </description>
+    <display-name>Stream YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -434,6 +473,11 @@
     <description>
       Determines whether to publish audit messages to Apache Kafka
     </description>
+    <display-name>Publish audit logs</display-name>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -570,18 +614,35 @@
 
   <property>
     <name>data.tx.num.cores</name>
-    <value>${master.service.num.cores}</value>
+    <value>2</value>
     <description>
       Maximum number of transaction client cores
     </description>
+    <display-name>Transaction client YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
     <name>data.tx.memory.mb</name>
-    <value>${master.service.memory.mb}</value>
+    <value>512</value>
     <description>
       Memory in megabytes of the transaction clients
     </description>
+    <display-name>Transaction client YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -688,6 +749,15 @@
     <description>
       Size of Memory in megabytes for each dataset executor instance
     </description>
+    <display-name>Dataset executor YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -696,6 +766,14 @@
     <description>
       Number of virtual cores for each dataset executor instance
     </description>
+    <display-name>Dataset executor YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -890,6 +968,11 @@
       ${metadata.updates.kafka.topic} to receive notifications of metadata
       updates.
     </description>
+    <display-name>Publish metadata updates</display-name>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <!-- New Metrics system settings -->
@@ -980,18 +1063,35 @@
 
   <property>
     <name>metrics.num.cores</name>
-    <value>${master.service.num.cores}</value>
+    <value>2</value>
     <description>
       Number of virtual cores for the metrics service
     </description>
+    <display-name>Metrics service YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
     <name>metrics.memory.mb</name>
-    <value>${master.service.memory.mb}</value>
+    <value>512</value>
     <description>
       Memory assigned to the metrics service in megabytes
     </description>
+    <display-name>Metrics service YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <!-- Metrics Processor Configuration -->
@@ -1020,6 +1120,14 @@
     <description>
       Number of cores for metrics processor service Apache Twill runnable
     </description>
+    <display-name>Metrics processor YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1029,6 +1137,15 @@
       Size of memory in megabytes for metrics processor service Apache Twill
       runnable
     </description>
+    <display-name>Metrics processor YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1087,6 +1204,14 @@
     <description>
       Number of cores for each log saver instance in YARN
     </description>
+    <display-name>Log saver YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1227,6 +1352,11 @@
     <description>
       Determines if the CDAP Explore Service (ad-hoc SQL queries) is enabled
     </description>
+    <display-name>Explore enabled</display-name>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1261,6 +1391,14 @@
     <description>
       Number of virtual cores for each explore executor instance
     </description>
+    <display-name>Explore executor YARN CPU cores</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>1</minimum>
+      <maximum>4</maximum>
+      <increment-step>1</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1269,6 +1407,15 @@
     <description>
       Size of Memory in megabytes for each explore executor instance
     </description>
+    <display-name>Explore executor YARN Memory</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>0</minimum>
+      <maximum>268435456</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -65,7 +65,7 @@
       settings. If any checks fail, the CDAP Master will fail to start instead of waiting for the problem to be fixed.
       This setting only affects Distributed CDAP. It does not apply to Standalone CDAP.
     </description>
-    <display-name>Master startup checks</display-name>
+    <display-name>Master Startup Checks</display-name>
     <value-attributes>
       <type>boolean</type>
       <overridable>false</overridable>
@@ -205,7 +205,7 @@
     <name>master.service.num.cores</name>
     <value>2</value>
     <description>Number of cores for Master Service instance</description>
-    <display-name>CDAP Master YARN CPU cores</display-name>
+    <display-name>CDAP Master YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -397,7 +397,7 @@
       Number of virtual core for the YARN container that runs the stream
       handler
     </description>
-    <display-name>Stream YARN CPU cores</display-name>
+    <display-name>Stream YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -473,7 +473,7 @@
     <description>
       Determines whether to publish audit messages to Apache Kafka
     </description>
-    <display-name>Publish audit logs</display-name>
+    <display-name>Publish Audit Logs</display-name>
     <value-attributes>
       <type>boolean</type>
       <overridable>false</overridable>
@@ -618,7 +618,7 @@
     <description>
       Maximum number of transaction client cores
     </description>
-    <display-name>Transaction client YARN CPU cores</display-name>
+    <display-name>Transaction Client YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -634,7 +634,7 @@
     <description>
       Memory in megabytes of the transaction clients
     </description>
-    <display-name>Transaction client YARN Memory</display-name>
+    <display-name>Transaction Client YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>0</minimum>
@@ -749,7 +749,7 @@
     <description>
       Size of Memory in megabytes for each dataset executor instance
     </description>
-    <display-name>Dataset executor YARN Memory</display-name>
+    <display-name>Dataset Executor YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>0</minimum>
@@ -766,7 +766,7 @@
     <description>
       Number of virtual cores for each dataset executor instance
     </description>
-    <display-name>Dataset executor YARN CPU cores</display-name>
+    <display-name>Dataset Executor YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -968,7 +968,7 @@
       ${metadata.updates.kafka.topic} to receive notifications of metadata
       updates.
     </description>
-    <display-name>Publish metadata updates</display-name>
+    <display-name>Publish Metadata Updates</display-name>
     <value-attributes>
       <type>boolean</type>
       <overridable>false</overridable>
@@ -1067,7 +1067,7 @@
     <description>
       Number of virtual cores for the metrics service
     </description>
-    <display-name>Metrics service YARN CPU cores</display-name>
+    <display-name>Metrics Service YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -1083,7 +1083,7 @@
     <description>
       Memory assigned to the metrics service in megabytes
     </description>
-    <display-name>Metrics service YARN Memory</display-name>
+    <display-name>Metrics Service YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>0</minimum>
@@ -1120,7 +1120,7 @@
     <description>
       Number of cores for metrics processor service Apache Twill runnable
     </description>
-    <display-name>Metrics processor YARN CPU cores</display-name>
+    <display-name>Metrics Processor YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -1137,7 +1137,7 @@
       Size of memory in megabytes for metrics processor service Apache Twill
       runnable
     </description>
-    <display-name>Metrics processor YARN Memory</display-name>
+    <display-name>Metrics Processor YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>0</minimum>
@@ -1204,7 +1204,7 @@
     <description>
       Number of cores for each log saver instance in YARN
     </description>
-    <display-name>Log saver YARN CPU cores</display-name>
+    <display-name>Log Saver YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -1352,7 +1352,7 @@
     <description>
       Determines if the CDAP Explore Service (ad-hoc SQL queries) is enabled
     </description>
-    <display-name>Explore enabled</display-name>
+    <display-name>Explore Enabled</display-name>
     <value-attributes>
       <type>boolean</type>
       <overridable>false</overridable>
@@ -1391,7 +1391,7 @@
     <description>
       Number of virtual cores for each explore executor instance
     </description>
-    <display-name>Explore executor YARN CPU cores</display-name>
+    <display-name>Explore Executor YARN CPU Cores</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>1</minimum>
@@ -1407,7 +1407,7 @@
     <description>
       Size of Memory in megabytes for each explore executor instance
     </description>
-    <display-name>Explore executor YARN Memory</display-name>
+    <display-name>Explore Executor YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
       <minimum>0</minimum>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -747,7 +747,7 @@
     <name>dataset.executor.container.memory.mb</name>
     <value>512</value>
     <description>
-      Size of Memory in megabytes for each dataset executor instance
+      Size of memory in megabytes for each dataset executor instance
     </description>
     <display-name>Dataset Executor YARN Memory</display-name>
     <value-attributes>


### PR DESCRIPTION
This improves the look on some of our important properties. I will be working on how to display these properties better using themes, but am wanting to get some of this into the next release, especially the booleans, as they present checkboxes instead of text boxes.

Things with "overridable = false" mean that whatever setting is applied is cluster wide and cannot be modified per-node or configuration group.

Advanced cdap-env.sh:
<img width="760" alt="screen shot 2016-05-11 at 7 08 36 pm" src="https://cloud.githubusercontent.com/assets/380021/15199541/093fc5a4-17ad-11e6-8238-d85c48507b21.png">

Example checkbox:
<img width="806" alt="screen shot 2016-05-11 at 7 09 04 pm" src="https://cloud.githubusercontent.com/assets/380021/15199545/10b7cade-17ad-11e6-946b-b71c27aa57d9.png">
