### PR TITLE
Insert dot.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ RPM_FPM_ARGS="-t rpm --rpm-os linux"
 DEB_FPM_ARGS="-t deb"
 
 if [[ ${PACKAGE_VERSION} =~ "-SNAPSHOT" ]] ; then
-  PACKAGE_VERSION=${PACKAGE_VERSION/-SNAPSHOT/$(date +%s)}
+  PACKAGE_VERSION=${PACKAGE_VERSION/-SNAPSHOT/.$(date +%s)}
 fi
 
 __failed=0


### PR DESCRIPTION
```
$ ./build.sh
Created deb package {:path=>"cdap-ambari-service_3.5.0.1463084293-1_all.deb"}
no value for epoch is set, defaulting to nil {:level=>:warn}
no value for epoch is set, defaulting to nil {:level=>:warn}
Created rpm {:path=>"cdap-ambari-service-3.5.0.1463084293-1.noarch.rpm"}
```
