### PR TITLE
CDAP-5000 Remove explore.executor.container.instances configurable

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -1380,12 +1380,6 @@
   </property>
 
   <property>
-    <name>explore.executor.container.instances</name>
-    <value>1</value>
-    <description>Number of explore executor instances</description>
-  </property>
-
-  <property>
     <name>explore.executor.container.num.cores</name>
     <value>1</value>
     <description>


### PR DESCRIPTION
This option shouldn't be configured, as any setting greater than 1 causes a problem. This is being removed from CDAP as of 3.5, but was invalid to modify under previous versions, anyway.
