### PR TITLE
Use cdap_kafka_brokers variable for metadata

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -989,7 +989,7 @@
 
   <property>
     <name>metadata.updates.kafka.broker.list</name>
-    <value>127.0.0.1:${kafka.bind.port}</value>
+    <value>{{cdap_kafka_brokers}}</value>
     <description>
       Apache Kafka broker list to which metadata update notifications are published
     </description>


### PR DESCRIPTION
We create `cdap_kafka_brokers` in `package/scripts/params.py` for use in `cdap-site.xml`'s `kafka.seed.brokers` so use the same set for `metadata.updates.kafka.broker.list` metadata update publishing.
