### PR TITLE
Restrict CDAP_CLIENT/CDAP_UI to depend only on cdap-site.xml

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -30,11 +30,6 @@
               <fileName>cdap-site.xml</fileName>
               <dictionaryName>cdap-site</dictionaryName>
             </configFile>
-            <configFile>
-              <type>env</type>
-              <fileName>cdap-env.sh</fileName>
-              <dictionaryName>cdap-env</dictionaryName>
-            </configFile>
           </configFiles>
           <configuration-dependencies>
             <config-type>cdap-site</config-type>
@@ -52,6 +47,18 @@
             <scriptType>PYTHON</scriptType>
             <timeout>600</timeout>
           </commandScript>
+          <configFiles>
+            <configFile>
+              <type>xml</type>
+              <fileName>cdap-site.xml</fileName>
+              <dictionaryName>cdap-site</dictionaryName>
+            </configFile>
+            <configFile>
+              <type>env</type>
+              <fileName>cdap-env.sh</fileName>
+              <dictionaryName>cdap-env</dictionaryName>
+            </configFile>
+          </configFiles>
           <dependencies>
             <dependency>
               <name>CDAP/CDAP_KAFKA</name>
@@ -162,6 +169,18 @@
             <scriptType>PYTHON</scriptType>
             <timeout>600</timeout>
           </commandScript>
+          <configFiles>
+            <configFile>
+              <type>xml</type>
+              <fileName>cdap-site.xml</fileName>
+              <dictionaryName>cdap-site</dictionaryName>
+            </configFile>
+            <configFile>
+              <type>env</type>
+              <fileName>cdap-env.sh</fileName>
+              <dictionaryName>cdap-env</dictionaryName>
+            </configFile>
+          </configFiles>
           <dependencies>
             <dependency>
               <name>ZOOKEEPER/ZOOKEEPER_SERVER</name>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -36,6 +36,9 @@
               <dictionaryName>cdap-env</dictionaryName>
             </configFile>
           </configFiles>
+          <configuration-dependencies>
+            <config-type>cdap-site</config-type>
+          </configuration-dependencies>
         </component>
 
         <component>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -198,6 +198,9 @@
             <scriptType>PYTHON</scriptType>
             <timeout>600</timeout>
           </commandScript>
+          <configuration-dependencies>
+            <config-type>cdap-site</config-type>
+          </configuration-dependencies>
         </component>
 
       </components>


### PR DESCRIPTION
Since `cdap-cli.sh` never reads from `cdap-env.sh` at invocation, we don't need to "restart" the client if it is changed, only if `cdap-site.xml` is changed.
