### PR TITLE
CDAP-4106 Ambari alerts for CDAP services

### DIFF
--- a/alerts.json
+++ b/alerts.json
@@ -1,0 +1,113 @@
+{
+  "CDAP": {
+    "CDAP_KAFKA": [
+      {
+        "name": "cdap_kafka_process",
+        "label": "CDAP Kafka Process",
+        "description": "This alert is triggered if the CDAP Kafka processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "interval": 1,
+        "scope": "ANY",
+        "source": {
+          "type": "PORT",
+          "uri": "{{cdap-site/kafka.bind.port}}",
+          "default_port": 9092,
+          "reporting": {
+            "ok": {
+              "text": "TCP OK - {0:.3f}s response on port {1}"
+            },
+            "warning": {
+              "text": "TCP OK - {0:.3f}s response on port {1}",
+              "value": 1.5
+            },
+            "critical": {
+              "text": "Connection failed: {0} to {1}:{2}",
+              "value": 5.0
+            }
+          }
+        }
+      }
+    ],
+    "CDAP_MASTER": [
+      {
+        "name": "cdap_master_process",
+        "label": "CDAP Master Process",
+        "description": "This alert is triggered if the CDAP Master processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "interval": 1,
+        "scope": "SERVICE",
+        "enabled": true,
+        "source": {
+          "type": "SCRIPT",
+          "path": "CDAP/package/alerts/alert_cdap_master_status.py"
+        }
+      }
+    ],
+    "CDAP_ROUTER": [
+      {
+        "name": "cdap_router_process",
+        "label": "CDAP Router Process",
+        "description": "This alert is triggered if the CDAP Router processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "interval": 1,
+        "scope": "ANY",
+        "enabled": true,
+        "source": {
+          "type": "WEB",
+          "uri": {
+            "http": "{{hostname}}:{{cdap-site/router.bind.port}}",
+            "https": "{{hostname}}:{{cdap-site/router.ssl.bind.port}}",
+            "https_property": "{{cdap-site/ssl.enabled}}",
+            "https_property_value": "true",
+            "default_port": 11015,
+            "connection_timeout": 5.0
+          },
+          "reporting": {
+            "ok": {
+              "text": "HTTP {0} response in {2:.3f}s"
+            },
+            "warning": {
+              "text": "HTTP {0} response from {1} in {2:.3f}s ({3})",
+              "value": 1.5
+            },
+            "critical": {
+              "text": "Connection failed to {1} ({3})",
+              "value": 5.0
+            }
+          }
+        }
+      }
+    ],
+    "CDAP_UI": [
+      {
+        "name": "cdap_ui_process",
+        "label": "CDAP UI Process",
+        "description": "This alert is triggered if the CDAP UI processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "interval": 1,
+        "scope": "ANY",
+        "enabled": true,
+        "source": {
+          "type": "WEB",
+          "uri": {
+            "http": "{{hostname}}:{{cdap-site/dashboard.bind.port}}",
+            "https": "{{hostname}}:{{cdap-site/dashboard.ssl.bind.port}}",
+            "https_property": "{{cdap-site/ssl.enabled}}",
+            "https_property_value": "true",
+            "default_port": 9999,
+            "connection_timeout": 5.0
+          },
+          "reporting": {
+            "ok": {
+              "text": "HTTP {0} response in {2:.3f}s"
+            },
+            "warning": {
+              "text": "HTTP {0} response from {1} in {2:.3f}s ({3})",
+              "value": 1.5
+            },
+            "critical": {
+              "text": "Connection failed to {1} ({3})",
+              "value": 5.0
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/alerts.json
+++ b/alerts.json
@@ -31,7 +31,7 @@
       {
         "name": "cdap_master_process",
         "label": "CDAP Master Process",
-        "description": "This alert is triggered if the CDAP Master processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "description": "This alert is triggered if the CDAP Master processes cannot be confirmed to be running for the configured critical threshold, given in seconds.",
         "interval": 1,
         "scope": "SERVICE",
         "enabled": true,

--- a/package/alerts/alert_cdap_master_status.py
+++ b/package/alerts/alert_cdap_master_status.py
@@ -25,6 +25,7 @@ RESULT_STATE_UNKNOWN = 'UNKNOWN'
 LOGGER_EXCEPTION_MESSAGE = "[Alert] CDAP Master Health on {0} fails:"
 logger = logging.getLogger('ambari_alerts')
 
+
 def execute(configurations={}, parameters={}, host_name=None):
     if configurations is None:
         return (RESULT_STATE_UNKNOWN, ['There were no configurations supplied to the script.'])

--- a/package/alerts/alert_cdap_master_status.py
+++ b/package/alerts/alert_cdap_master_status.py
@@ -1,0 +1,36 @@
+# coding=utf8
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+import logging
+
+from resource_management import *
+
+RESULT_STATE_OK = 'OK'
+RESULT_STATE_CRITICAL = 'CRITICAL'
+RESULT_STATE_UNKNOWN = 'UNKNOWN'
+
+LOGGER_EXCEPTION_MESSAGE = "[Alert] CDAP Master Health on {0} fails:"
+logger = logging.getLogger('ambari_alerts')
+
+def execute(configurations={}, parameters={}, host_name=None):
+    if configurations is None:
+        return (RESULT_STATE_UNKNOWN, ['There were no configurations supplied to the script.'])
+    try:
+        check_cmd = format('service cdap-master status')
+        Execute(check_cmd, timeout=5)
+        return(RESULT_STATE_OK, ['Master OK - CDAP Master is running'])
+    except:
+        return(RESULT_STATE_CRITICAL, [LOGGER_EXCEPTION_MESSAGE])


### PR DESCRIPTION
This checks the following CDAP services:
- [x] Kafka - TCP check
- [x] Master - SCRIPT check (uses init script `status`)
- [x] Router - HTTP check
- [x] UI - HTTP check
- [ ] Auth - Not implemented... will be done when Auth service is added

_NOTE_: This is setup to support SSL, even though SSL support isn't configured in the service.
