### PR TITLE
CDAP-4107 Support CDAP HA via Ambari

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -43,7 +43,8 @@
           <name>CDAP_MASTER</name>
           <displayName>CDAP Master</displayName>
           <category>MASTER</category>
-          <cardinality>1</cardinality>
+          <cardinality>1+</cardinality>
+          <timelineAppid>CDAP</timelineAppid>
           <commandScript>
             <script>scripts/master.py</script>
             <scriptType>PYTHON</scriptType>
@@ -153,7 +154,8 @@
           <name>CDAP_ROUTER</name>
           <displayName>CDAP Router</displayName>
           <category>MASTER</category>
-          <cardinality>1</cardinality>
+          <cardinality>1+</cardinality>
+          <timelineAppid>CDAP</timelineAppid>
           <commandScript>
             <script>scripts/router.py</script>
             <scriptType>PYTHON</scriptType>
@@ -189,7 +191,8 @@
           <name>CDAP_UI</name>
           <displayName>CDAP UI</displayName>
           <category>MASTER</category>
-          <cardinality>1</cardinality>
+          <cardinality>1+</cardinality>
+          <timelineAppid>CDAP</timelineAppid>
           <commandScript>
             <script>scripts/ui.py</script>
             <scriptType>PYTHON</scriptType>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -120,7 +120,7 @@ cdap_kafka_brokers = tmp_kafka_hosts
 router_hosts = config['clusterHostInfo']['cdap_router_hosts']
 router_hosts.sort()
 if len(router_hosts) > 1:
-    for i, val in enumerate(router_hosts):
+    for val in router_hosts:
         if val == hostname:
             cdap_router_host = hostname
     if cdap_router_host == hostname:

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -119,6 +119,15 @@ cdap_kafka_brokers = tmp_kafka_hosts
 
 router_hosts = config['clusterHostInfo']['cdap_router_hosts']
 router_hosts.sort()
-cdap_router_host = router_hosts[0]
+if len(router_hosts) > 1:
+    for i, val in enumerate(router_hosts):
+        if val == hostname:
+            cdap_router_host = hostname
+    if cdap_router_host == hostname:
+        pass
+    else:
+        cdap_router_host = router_hosts[0]
+else:
+    cdap_router_host = router_hosts[0]
 
 # TODO: cdap_auth_server_hosts cdap_ui_hosts


### PR DESCRIPTION
This allows for HA configuration of CDAP services:
- [x] Master
- [x] Router
- [x] UI
- [ ] Auth - will be implemented with Auth service

This also changes the `cdap_router_host` variable to use any CDAP Router services running on the same host as the script, and simply returning the first host when it is not, which was the previous behavior. This ensures that co-located CDAP services will use the local CDAP Router versus traversing the network.

_NOTE_: There is no wizard for enabling HA. Instead, you must select multiple hosts for the services at CDAP installation, or you must add instances of the CDAP components on a specific hosts' page in Ambari.

<img width="572" alt="screen shot 2016-07-06 at 4 13 28 pm" src="https://cloud.githubusercontent.com/assets/380021/16635856/74a49d9e-43a2-11e6-876a-a07d5185e085.png">
