### PR TITLE
CDAP-6362 Support SSL for CDAP

### DIFF
--- a/configuration/cdap-security.xml
+++ b/configuration/cdap-security.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+
+<configuration supports_final="true">
+
+  <!-- Router SSL -->
+
+  <property>
+    <name>router.ssl.keystore.path</name>
+    <value></value>
+    <description>
+      Keystore file location, either absolute or relative; the file should be owned and readable only by the CDAP user
+    </description>
+  </property>
+
+  <property>
+    <name>router.ssl.keystore.password</name>
+    <value></value>
+    <property-type>PASSWORD</property-type>
+    <description>
+      Keystore password
+    </description>
+    <value-attributes>
+      <overridable>false</overridable>
+    </value-attributes>
+  </property>
+
+  <property>
+    <name>router.ssl.keystore.keypassword</name>
+    <value></value>
+    <property-type>PASSWORD</property-type>
+    <description>
+      Keystore key password
+    </description>
+    <value-attributes>
+      <overridable>false</overridable>
+    </value-attributes>
+  </property>
+
+  <property>
+    <name>router.ssl.keystore.type</name>
+    <value>JKS</value>
+    <description>
+      Keystore file type
+    </description>
+  </property>
+
+  <!-- UI SSL -->
+
+  <property>
+    <name>dashboard.ssl.cert</name>
+    <value></value>
+    <description>
+      SSL cert file location, either absolute or relative; the file should be owned and readable only by the CDAP user
+    </description>
+  </property>
+
+  <property>
+    <name>dashboard.ssl.key</name>
+    <value></value>
+    <description>
+      SSL key file location, either absolute or relative; the file should be owned and readable only by the CDAP user
+    </description>
+  </property>
+
+</configuration>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -880,7 +880,6 @@
     </description>
   </property>
 
-  <!-- Disable until SSL support
   <property>
     <name>router.ssl.bind.port</name>
     <value>10443</value>
@@ -893,9 +892,10 @@
     <name>router.ssl.server.port</name>
     <value>${router.ssl.bind.port}</value>
     <final>true</final>
+    <description>
+      CDAP Router service port to which CDAP UI connects when using SSL
+    </description>
   </property>
-
-  -->
 
   <!-- Kerberos -->
 
@@ -939,6 +939,22 @@
     <description>
       Relogin interval for Kerberos keytab
     </description>
+  </property>
+
+  <!-- Security configuration -->
+
+  <property>
+    <name>ssl.enabled</name>
+    <value>false</value>
+    <description>
+      Determines if SSL is enabled for CDAP HTTP endpoints
+    </description>
+    <display-name>SSL Enabled</display-name>
+    <final>true</final>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1350,7 +1366,6 @@
     </description>
   </property>
 
-  <!-- Disable until SSL support
   <property>
     <name>dashboard.ssl.bind.port</name>
     <value>9443</value>
@@ -1366,7 +1381,6 @@
       True to disable SSL certificate check from the CDAP UI
     </description>
   </property>
-  -->
 
   <property>
     <name>router.server.boss.threads</name>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -231,10 +231,11 @@
 
       <!-- names for config files (under configuration dir) -->
       <configuration-dependencies>
-        <config-type>cdap-site</config-type>
         <config-type>cdap-env</config-type>
+        <config-type>cdap-security</config-type>
+        <config-type>cdap-site</config-type>
       </configuration-dependencies>
-      <restartRequiredAfterChange>false</restartRequiredAfterChange>
+      <restartRequiredAfterChange>true</restartRequiredAfterChange>
     </service>
   </services>
 </metainfo>


### PR DESCRIPTION
This adds SSL support to CDAP.
- [x] `cdap-site.xml`
  - [x] `ssl.enabled` and `*.ssl.bind.*` and `*.ssl.server.*`
- [x] `cdap-security.xml`
  - [x] Router SSL options
  - [x] UI SSL options

Ambari doesn't appear to have any way to generate certificates. It looks like the user must create these certificates and place them on the appropriate cluster hosts.

Auth Server is being implemented separately, so there's nothing related to that service here.
