### PR TITLE
CDAP-6363 Provide service dependencies for Ambari 2.2+

### DIFF
--- a/role_command_order.json
+++ b/role_command_order.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "This extends the default set of dependencies with our own",
+  "general_deps": {
+    "CDAP_KAFKA-START": [
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "CDAP_MASTER-START": [
+      "ZOOKEEPER_SERVER-START",
+      "NAMENODE-START",
+      "DATANODE-START",
+      "HBASE_MASTER-START",
+      "HBASE_REGIONSERVER-START",
+      "RESOURCEMANAGER-START",
+      "NODEMANAGER-START",
+      "HIVE_METASTORE-START",
+      "HISTORYSERVER-START"
+    ],
+    "CDAP_ROUTER-START": [
+      "ZOOKEEPER_SERVER-START"
+    ],
+    "ZOOKEEPER_SERVER-STOP": [
+      "CDAP_KAFKA-STOP",
+      "CDAP_MASTER-STOP",
+      "CDAP_ROUTER-STOP"
+    ],
+    "NAMENODE-STOP": [
+      "CDAP_MASTER-STOP"
+    ],
+    "HBASE_MASTER-STOP": [
+      "CDAP_MASTER-STOP"
+    ],
+    "RESOURCEMANAGER-STOP": [
+      "CDAP_MASTER-STOP"
+    ]
+  },
+  "_comment": "Dependencies that are used when GLUSTERFS is not present in cluster",
+  "optional_no_glusterfs": {
+    "NAMENODE-STOP": [
+      "CDAP_MASTER-STOP"
+    ]
+  }
+}


### PR DESCRIPTION
This provides dependencies for CDAP when used on Ambari 2.2+

https://cwiki.apache.org/confluence/display/AMBARI/How-To+Define+Stacks+and+Services#How-ToDefineStacksandServices-RoleCommandOrder
