### PR TITLE
CDAP-6361 Create quicklinks to CDAP web services

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -1658,6 +1658,26 @@
     </description>
   </property>
 
+  <!-- Unused by CDAP, but used by Ambari UI -->
+
+  <property>
+    <name>dashboard.server.address</name>
+    <value>{{cdap_ui_host}}</value>
+    <description>
+      Address for CDAP UI
+    </description>
+  </property>
+
+  <property>
+    <name>dashboard.ssl.server.address</name>
+    <value>{{cdap_ui_host}}</value>
+    <description>
+      Address for CDAP UI over SSL
+    </description>
+  </property>
+
+  <!-- End Ambari-only Dashboard options -->
+
   <property>
     <name>dashboard.router.check.timeout.secs</name>
     <value>0</value>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -250,6 +250,13 @@
         </theme>
       </themes>
 
+      <quickLinksConfigurations>
+        <quickLinksConfiguration>
+          <fileName>quicklinks.json</fileName>
+          <default>true</default>
+        </quickLinksConfiguration>
+      </quickLinksConfigurations>
+
       <commandScript>
         <script>scripts/service_check.py</script>
         <scriptType>PYTHON</scriptType>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -128,4 +128,9 @@ if len(router_hosts) > 1:
 else:
     cdap_router_host = router_hosts[0]
 
-# TODO: cdap_auth_server_hosts cdap_ui_hosts
+# Return first host, if more than one
+ui_hosts = config['clusterHostInfo']['cdap_ui_hosts']
+ui_hosts.sort()
+cdap_ui_host = ui_hosts[0]
+
+# TODO: cdap_auth_server_hosts

--- a/quicklinks/quicklinks.json
+++ b/quicklinks/quicklinks.json
@@ -1,0 +1,31 @@
+{
+  "name": "default",
+  "description": "Quick Links for CDAP services",
+  "configuration": {
+    "protocol": {
+      "type": "https",
+      "checks": [
+        {
+          "property": "ssl.enabled",
+          "desired": "true",
+          "site": "cdap-site"
+        }
+      ]
+    },
+    "links": [
+      {
+        "name": "cdap_ui",
+        "label": "CDAP UI",
+        "requires_user_name": "false",
+        "url": "%@://%@:%@",
+        "port": {
+          "http_property": "dashboard.server.address",
+          "http_default_port": "9999",
+          "https_property": "dashboard.ssl.server.address",
+          "https_default_port": "9443",
+          "site": "cdap-site"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds Quick Links to Ambari's CDAP page in the Ambari UI. To do this, we've created two new properties which aren't actually used by CDAP itself, but which will be used by Ambari.

This requires #79 for SSL detection.
