### PR TITLE
Move CDAP to common-services and extend in stacks

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0"?>
+<!--
+   Copyright © 2015-2016 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
 <metainfo>
   <schemaVersion>2.0</schemaVersion>
   <services>

--- a/stacks/HDP/2.0.6/services/CDAP/metainfo.xml
+++ b/stacks/HDP/2.0.6/services/CDAP/metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2016 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>CDAP</name>
+      <extends>common-services/CDAP/3.5.0-SNAPSHOT</extends>
+    </service>
+  </services>
+</metainfo>

--- a/stacks/HDP/2.1/services/CDAP/metainfo.xml
+++ b/stacks/HDP/2.1/services/CDAP/metainfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2016 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>CDAP</name>
+
+      <components>
+        <component>
+          <name>CDAP_MASTER</name>
+          <dependencies>
+            <dependency>
+              <name>TEZ/TEZ_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+          </dependencies>
+        </component>
+      </components>
+
+    </service>
+  </services>
+</metainfo>

--- a/stacks/HDP/2.1/services/CDAP/metainfo.xml
+++ b/stacks/HDP/2.1/services/CDAP/metainfo.xml
@@ -34,7 +34,9 @@
           </dependencies>
         </component>
       </components>
-
+      <configuration-dependencies>
+        <config-type>tez-site</config-type>
+      </configuration-dependencies>
     </service>
   </services>
 </metainfo>


### PR DESCRIPTION
This moves the CDAP service from `resources/stacks/HDP/*/services/CDAP` to `resources/common-services/CDAP/${PACKAGE_VERSION}` and now has a `stacks` directory that allows us to set specific changes for specific HDP versions... (for example, TEZ is introduced in HDP 2.1)
