### PR TITLE
Update alerts to use /status endpoints for Router/UI

### DIFF
--- a/alerts.json
+++ b/alerts.json
@@ -52,8 +52,8 @@
         "source": {
           "type": "WEB",
           "uri": {
-            "http": "{{hostname}}:{{cdap-site/router.bind.port}}",
-            "https": "{{hostname}}:{{cdap-site/router.ssl.bind.port}}",
+            "http": "{{hostname}}:{{cdap-site/router.bind.port}}/status",
+            "https": "{{hostname}}:{{cdap-site/router.ssl.bind.port}}/status",
             "https_property": "{{cdap-site/ssl.enabled}}",
             "https_property_value": "true",
             "default_port": 11015,
@@ -86,8 +86,8 @@
         "source": {
           "type": "WEB",
           "uri": {
-            "http": "{{hostname}}:{{cdap-site/dashboard.bind.port}}",
-            "https": "{{hostname}}:{{cdap-site/dashboard.ssl.bind.port}}",
+            "http": "{{hostname}}:{{cdap-site/dashboard.bind.port}}/status",
+            "https": "{{hostname}}:{{cdap-site/dashboard.ssl.bind.port}}/status",
             "https_property": "{{cdap-site/ssl.enabled}}",
             "https_property_value": "true",
             "default_port": 9999,


### PR DESCRIPTION
Otherwise, we will get a 404 when checking Router (403 when Auth is implemented)
