### PR TITLE
Use correct key for kafka_broker_hosts

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -106,7 +106,7 @@ for i, val in enumerate(zk_hosts):
 cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace
 
 kafka_bind_port = str(default('/configurations/kafka-broker/port', None))
-kafka_hosts = config['clusterHostInfo']['kafka_brokers_hosts']
+kafka_hosts = config['clusterHostInfo']['kafka_broker_hosts']
 kafka_hosts.sort()
 tmp_kafka_hosts = ''
 for i, val in enumerate(kafka_hosts):


### PR DESCRIPTION
Fixes typo....

Reference: https://github.com/apache/ambari/blob/b166a020d0784192d899ed333a0883176c8ef53e/ambari-server/src/main/resources/common-services/KAFKA/0.8.1/package/scripts/params.py#L92
