### PR TITLE
Allow empty values to remain empty

### DIFF
--- a/configuration/cdap-security.xml
+++ b/configuration/cdap-security.xml
@@ -26,6 +26,10 @@
     <description>
       Keystore file location, either absolute or relative; the file should be owned and readable only by the CDAP user
     </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -36,6 +40,7 @@
       Keystore password
     </description>
     <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
       <overridable>false</overridable>
     </value-attributes>
   </property>
@@ -48,6 +53,7 @@
       Keystore key password
     </description>
     <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
       <overridable>false</overridable>
     </value-attributes>
   </property>
@@ -68,6 +74,10 @@
     <description>
       SSL cert file location, either absolute or relative; the file should be owned and readable only by the CDAP user
     </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -76,6 +86,10 @@
     <description>
       SSL key file location, either absolute or relative; the file should be owned and readable only by the CDAP user
     </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
 </configuration>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -255,6 +255,9 @@
     <description>
       Extra Java classpath for CDAP programs
     </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
   </property>
 
   <property>
@@ -409,11 +412,6 @@
     <description>
       Maximum number of transaction client instances
     </description>
-    <value-attributes>
-      <type>int</type>
-      <minimum>1</minimum>
-      <overridable>false</overridable>
-    </value-attributes>
   </property>
 
   <property>
@@ -1439,6 +1437,9 @@
       The full path to the Kerberos keytab file containing the CDAP Master service's
       credentials
     </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
   </property>
 
   <property>
@@ -1451,6 +1452,9 @@
       EXAMPLE.COM. The string "_HOST" will be substituted with the local
       hostname.
     </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
   </property>
 
   <property>


### PR DESCRIPTION
Otherwise, Ambari will require that these are entered by the user.
