### PR TITLE
Run xmllint to catch XML syntax issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ python:
   - 2.7
 sudo: false
 install: 'pip install pep8'
-script: 'pep8 .'
+script:
+  - pep8 .
+  - xmllint $(find . -name "*.xml")


### PR DESCRIPTION
Since Travis has `xmllint` available in their containers, we should take advantage of it.
