### PR TITLE
Fix theme to display Master/Router heap sizes

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -72,7 +72,7 @@
     <value-attributes>
       <type>int</type>
       <minimum>256</minimum>
-      <maximum>268435456</maximum>
+      <maximum>8192</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
       <overridable>false</overridable>
@@ -87,7 +87,7 @@
     <value-attributes>
       <type>int</type>
       <minimum>256</minimum>
-      <maximum>268435456</maximum>
+      <maximum>8192</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
       <overridable>false</overridable>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -423,7 +423,7 @@
     <display-name>Transaction Client YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -574,7 +574,7 @@
     <display-name>Dataset Executor YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -683,7 +683,7 @@
     <display-name>Explore Executor YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -835,7 +835,7 @@
     <description>Memory in megabytes allocated for log saver instances to run in YARN</description>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -941,7 +941,7 @@
     <display-name>CDAP Master YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -1138,7 +1138,7 @@
     <display-name>Metrics Service YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -1193,7 +1193,7 @@
     <display-name>Metrics Processor YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>
@@ -1548,7 +1548,7 @@
     <display-name>Stream YARN Memory</display-name>
     <value-attributes>
       <type>int</type>
-      <minimum>0</minimum>
+      <minimum>256</minimum>
       <maximum>268435456</maximum>
       <unit>MB</unit>
       <increment-step>256</increment-step>

--- a/themes/theme.json
+++ b/themes/theme.json
@@ -61,15 +61,11 @@
       "configuration-layout": "default",
       "configs": [
         {
-          "config": "cdap-site/root.namespace",
-          "subsection-name": "subsection-master-col1"
-        },
-        {
           "config": "cdap-env/cdap_master_heapsize",
           "subsection-name": "subsection-master-col1"
         },
         {
-          "config": "cdap-site/router.webapp.enabled",
+          "config": "cdap-env/cdap_router_heapsize",
           "subsection-name": "subsection-router-col1"
         }
       ]
@@ -77,6 +73,17 @@
     "widgets": [
       {
         "config": "cdap-env/cdap_master_heapsize",
+        "widget": {
+          "type": "slider",
+          "units": [
+            {
+              "unit-name": "GB"
+            }
+          ]
+        }
+      },
+      {
+        "config": "cdap-env/cdap_router_heapsize",
         "widget": {
           "type": "slider",
           "units": [


### PR DESCRIPTION
Ambari themes need three sections:
- layouts
- placement
- widgets

Any configuration listed in placement must exist in widgets and each tab/section/subsection/column/row needs to have something in placement.

The theme we shipped in 3.4 was invalid. This caused it to look this this:
<img width="901" alt="screen shot 2016-07-15 at 11 47 57 am" src="https://cloud.githubusercontent.com/assets/380021/16880494/87e0f050-4a83-11e6-9f4b-6962f60f9e6d.png">

This is a _very_ minor and simple change to instead look like this:
<img width="866" alt="screen shot 2016-07-15 at 11 42 57 am" src="https://cloud.githubusercontent.com/assets/380021/16880596/fbfd6bda-4a83-11e6-8f12-2f488df47334.png">

I will create another PR which will update this to be a much more useful set of options displayed to the user. Take HBase as an example:
https://cwiki.apache.org/confluence/download/attachments/61326423/Screen%20Shot%202015-10-30%20at%205.49.21%20PM.png?version=1&modificationDate=1446252614000&api=v2
