### PR TITLE
Update CDAP_MASTER alert script location

### DIFF
--- a/alerts.json
+++ b/alerts.json
@@ -10,7 +10,7 @@
         "enabled": true,
         "source": {
           "type": "SCRIPT",
-          "path": "CDAP/package/alerts/alert_cdap_master_status.py"
+          "path": "CDAP/3.5.0-SNAPSHOT/package/alerts/alert_cdap_master_status.py"
         }
       }
     ],

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ install() {
   cp -a stacks var/lib/ambari-server/resources 2>/dev/null
   sed -i'' -e "s/3.5.0-SNAPSHOT/${PACKAGE_VERSION}/g" \
     var/lib/ambari-server/resources/stacks/*/*/services/CDAP/metainfo.xml \
+    var/lib/ambari-server/resources/common-services/CDAP/${PACKAGE_VERSION}/alerts.xml \
     var/lib/ambari-server/resources/common-services/CDAP/${PACKAGE_VERSION}/metainfo.xml
 }
 

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ install() {
   cp -a stacks var/lib/ambari-server/resources 2>/dev/null
   sed -i'' -e "s/3.5.0-SNAPSHOT/${PACKAGE_VERSION}/g" \
     var/lib/ambari-server/resources/stacks/*/*/services/CDAP/metainfo.xml \
-    var/lib/ambari-server/resources/common-services/CDAP/${PACKAGE_VERSION}/alerts.xml \
+    var/lib/ambari-server/resources/common-services/CDAP/${PACKAGE_VERSION}/alerts.json \
     var/lib/ambari-server/resources/common-services/CDAP/${PACKAGE_VERSION}/metainfo.xml
 }
 


### PR DESCRIPTION
Update `alerts.json` with the new location of the Master alerts script. The location was changed in #82 to a known location.
