### PR TITLE
Default to 6667, not None, if not configured

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -105,7 +105,7 @@ for i, val in enumerate(zk_hosts):
         zookeeper_hosts += ','
 cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace
 
-kafka_bind_port = str(default('/configurations/kafka-broker/port', None))
+kafka_bind_port = str(default('/configurations/kafka-broker/port', 6667))
 kafka_hosts = config['clusterHostInfo']['kafka_broker_hosts']
 kafka_hosts.sort()
 tmp_kafka_hosts = ''


### PR DESCRIPTION
If `port` is not configured, we end up with `None` in CDAP's `kafka.seed.brokers` rather than the actual default port.
