### PR TITLE
CDAP-6512 Remove root.namespace from zookeeper.quorum

### DIFF
--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -103,7 +103,7 @@ for i, val in enumerate(zk_hosts):
     zookeeper_hosts += val + ':' + zk_client_port
     if (i + 1) < len(zk_hosts):
         zookeeper_hosts += ','
-cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace
+cdap_zookeeper_quorum = zookeeper_hosts
 
 kafka_bind_port = str(default('/configurations/kafka-broker/port', 6667))
 kafka_hosts = config['clusterHostInfo']['kafka_broker_hosts']


### PR DESCRIPTION
Otherwise, we are unable to properly communicate with the Ambari-provided Kafka.
