### PR TITLE
Restore CDAP Kafka

### DIFF
--- a/alerts.json
+++ b/alerts.json
@@ -48,6 +48,33 @@
         }
       }
     ],
+    "CDAP_KAFKA": [
+      {
+        "name": "cdap_kafka_process",
+        "label": "CDAP Kafka Process",
+        "description": "This alert is triggered if the CDAP Kafka processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
+        "interval": 1,
+        "scope": "ANY",
+        "source": {
+          "type": "PORT",
+          "uri": "{{cdap-site/kafka.bind.port}}",
+          "default_port": 9092,
+          "reporting": {
+            "ok": {
+              "text": "TCP OK - {0:.3f}s response on port {1}"
+            },
+            "warning": {
+              "text": "TCP OK - {0:.3f}s response on port {1}",
+              "value": 1.5
+            },
+            "critical": {
+              "text": "Connection failed: {0} to {1}:{2}",
+              "value": 5.0
+            }
+          }
+        }
+      }
+    ],
     "CDAP_UI": [
       {
         "name": "cdap_ui_process",

--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -95,6 +95,21 @@
   </property>
 
   <property>
+    <name>cdap_kafka_heapsize</name>
+    <value>1024</value>
+    <description>CDAP Kafka Heap Size</description>
+    <display-name>CDAP Kafka Heap Size</display-name>
+    <value-attributes>
+      <type>int</type>
+      <minimum>256</minimum>
+      <maximum>8192</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
+  </property>
+
+  <property>
     <name>cdap_user</name>
     <value>cdap</value>
     <property-type>USER</property-type>
@@ -138,6 +153,7 @@ export CDAP_HOME=/opt/cdap
 export CDAP_CONF={{cdap_conf_dir}}
 export LOG_DIR={{log_dir}}
 export PID_DIR={{pid_dir}}
+export KAFKA_JAVA_HEAPMAX="-Xmx{{cdap_kafka_heapsize}}m"
 export MASTER_JAVA_HEAPMAX="-Xmx{{cdap_master_heapsize}}m"
 export ROUTER_JAVA_HEAPMAX="-Xmx{{cdap_router_heapsize}}m"
 {% if security_enabled %}

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -1508,6 +1508,51 @@
     </description>
   </property>
 
+  <!-- Kafka Configuration -->
+
+  <property>
+    <name>kafka.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      CDAP Kafka service bind address
+    </description>
+  </property>
+
+  <property>
+    <name>kafka.bind.port</name>
+    <value>9092</value>
+    <description>CDAP Kafka service bind port</description>
+  </property>
+
+  <property>
+    <name>kafka.num.partitions</name>
+    <value>10</value>
+    <description>Default number of partitions for a topic</description>
+  </property>
+
+  <property>
+    <name>kafka.log.dir</name>
+    <value>/data/cdap-kafka/logs</value>
+    <description>CDAP Kafka service log storage directory</description>
+  </property>
+
+  <property>
+    <name>kafka.zookeeper.namespace</name>
+    <value>kafka</value>
+    <description>CDAP Kafka service ZooKeeper namespace</description>
+  </property>
+
+  <property>
+    <name>kafka.default.replication.factor</name>
+    <value>1</value>
+    <description>
+      CDAP Kafka service replication factor; used to replicate Kafka messages across multiple
+      machines to prevent data loss in the event of a hardware failure. The recommended
+      setting is to run at least two CDAP Kafka servers. If you are running two CDAP Kafka
+      servers, set this value to 2; otherwise, set it to the number of CDAP Kafka servers.
+    </description>
+  </property>
+
   <!-- Security Configuration -->
 
   <property>

--- a/kerberos.json
+++ b/kerberos.json
@@ -69,6 +69,32 @@
           ]
         },
         {
+          "name": "CDAP_KAFKA",
+          "identities": [
+            {
+              "name": "cdap_kafka_cdap",
+              "principal": {
+                "value": "cdap/_HOST@${realm}",
+                "type" : "service",
+                "configuration": "cdap-site/cdap.master.kerberos.principal",
+                "local_username": "cdap"
+              },
+              "keytab": {
+                "file": "${keytab_dir}/cdap.service.keytab",
+                "owner": {
+                  "name": "cdap",
+                  "access": "r"
+                },
+                "group": {
+                  "name": "${cluster-env/user_group}",
+                  "access": ""
+                },
+                "configuration": "cdap-site/cdap.master.kerberos.keytab"
+              }
+            }
+          ]
+        },
+        {
           "name": "CDAP_AUTH_SERVER",
           "identities": [
             {

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -106,7 +106,7 @@
           </customCommands>
           <dependencies>
             <dependency>
-              <name>KAKFA/KAFKA_BROKER</name>
+              <name>CDAP/CDAP_KAFKA</name>
               <scope>cluster</scope>
               <auto-deploy>
                 <enabled>true</enabled>
@@ -218,6 +218,36 @@
         </component>
 
         <component>
+          <!-- CDAP Kafka Server-->
+          <name>CDAP_KAFKA</name>
+          <displayName>CDAP Kafka Server</displayName>
+          <category>MASTER</category>
+          <cardinality>1+</cardinality>
+          <commandScript>
+            <script>scripts/kafka.py</script>
+            <scriptType>PYTHON</scriptType>
+            <timeout>600</timeout>
+          </commandScript>
+          <dependencies>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_SERVER</name>
+              <scope>cluster</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+                <co-locate>CDAP/CDAP_MASTER</co-locate>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>ZOOKEEPER/ZOOKEEPER_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+          </dependencies>
+        </component>
+
+        <component>
           <!-- CDAP UI -->
           <name>CDAP_UI</name>
           <displayName>CDAP UI</displayName>
@@ -318,7 +348,6 @@
         <service>YARN</service>
         <service>ZOOKEEPER</service>
         <service>HIVE</service>
-        <service>KAFKA</service>
       </requiredServices>
 
       <!-- names for config files (under configuration dir) -->

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -1,0 +1,71 @@
+# coding=utf8
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+import ambari_helpers as helpers
+from resource_management import *
+
+
+class Kafka(Script):
+    def install(self, env):
+        print 'Install the CDAP Kafka Server'
+        import params
+        # Add repository file
+        helpers.add_repo(
+            params.files_dir + params.repo_file,
+            params.os_repo_dir
+        )
+        # Install any global packages
+        self.install_packages(env)
+        # Install package
+        helpers.package('cdap-kafka')
+        self.configure(env)
+
+    def start(self, env):
+        print 'Start the CDAP Kafka Server'
+        import params
+        import status_params
+        env.set_params(params)
+        self.configure(env)
+        daemon_cmd = format('/opt/cdap/kafka/bin/svc-kafka-server start')
+        no_op_test = format('ls {status_params.cdap_kafka_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_kafka_pid_file}) >/dev/null 2>&1')
+        Execute(
+            daemon_cmd,
+            user=params.cdap_user,
+            not_if=no_op_test
+        )
+
+    def stop(self, env):
+        print 'Stop the CDAP Kafka Server'
+        Execute('service cdap-kafka-server stop')
+
+    def status(self, env):
+        Execute('service cdap-kafka-server status')
+
+    def configure(self, env):
+        print 'Configure the CDAP Kafka Server'
+        import params
+        env.set_params(params)
+        helpers.cdap_config('kafka')
+
+        Directory(
+            params.kafka_log_dir,
+            owner=params.cdap_user,
+            group=params.user_group,
+            recursive=True
+        )
+
+if __name__ == "__main__":
+    Kafka().execute()

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -53,6 +53,7 @@ else:
 cdap_user = config['configurations']['cdap-env']['cdap_user']
 log_dir = config['configurations']['cdap-env']['cdap_log_dir']
 pid_dir = config['configurations']['cdap-env']['cdap_pid_dir']
+cdap_kafka_heapsize = config['configurations']['cdap-env']['cdap_kafka_heapsize']
 cdap_master_heapsize = config['configurations']['cdap-env']['cdap_master_heapsize']
 cdap_router_heapsize = config['configurations']['cdap-env']['cdap_router_heapsize']
 
@@ -105,8 +106,12 @@ for i, val in enumerate(zk_hosts):
         zookeeper_hosts += ','
 cdap_zookeeper_quorum = zookeeper_hosts + '/' + root_namespace
 
-kafka_bind_port = str(default('/configurations/kafka-broker/port', 6667))
-kafka_hosts = config['clusterHostInfo']['kafka_broker_hosts']
+kafka_log_dir = map_cdap_site['kafka.log.dir']
+# CDAP requires Kafka 0.8, so use CDAP_KAFKA
+# kafka_bind_port = str(default('/configurations/kafka-broker/port', 6667))
+# kafka_hosts = config['clusterHostInfo']['kafka_broker_hosts']
+kafka_bind_port = str(default('/configurations/cdap-site/kafka.bind.port', 9092))
+kafka_hosts = config['clusterHostInfo']['cdap_kafka_hosts']
 kafka_hosts.sort()
 tmp_kafka_hosts = ''
 for i, val in enumerate(kafka_hosts):

--- a/package/scripts/status_params.py
+++ b/package/scripts/status_params.py
@@ -23,6 +23,7 @@ cdap_user = config['configurations']['cdap-env']['cdap_user']
 pid_dir = config['configurations']['cdap-env']['cdap_pid_dir']
 
 cdap_auth_pid_file = pid_dir + '/auth-server-' + cdap_user + '.pid'
+cdap_kafka_pid_file = pid_dir + '/kafka-server-' + cdap_user + '.pid'
 cdap_master_pid_file = pid_dir + '/master-' + cdap_user + '.pid'
 cdap_router_pid_file = pid_dir + '/router-' + cdap_user + '.pid'
 cdap_ui_pid_file = pid_dir + '/ui-' + cdap_user + '.pid'

--- a/themes/theme.json
+++ b/themes/theme.json
@@ -126,6 +126,10 @@
           "subsection-name": "subsection-cdap-features-col1"
         },
         {
+          "config": "cdap-env/cdap_kafka_heapsize",
+          "subsection-name": "subsection-java-services-col1"
+        },
+        {
           "config": "cdap-env/cdap_master_heapsize",
           "subsection-name": "subsection-java-services-col1"
         },
@@ -218,6 +222,17 @@
         "config": "cdap-site/master.startup.checks.enabled",
         "widget": {
           "type": "toggle"
+        }
+      },
+      {
+        "config": "cdap-env/cdap_kafka_heapsize",
+        "widget": {
+          "type": "slider",
+          "units": [
+            {
+              "unit-name": "GB"
+            }
+          ]
         }
       },
       {


### PR DESCRIPTION
The version of Kafka shipped by Hortonworks isn't consistent even across HDP minor releases. CDAP requires Kafka 0.8, so we need to provide our own Kafka service. This supersedes #99 and is mostly a revert of #83 with additional changes to bring the service in-line with develop functionality.
- [x] CDAP/CDAP_KAFKA service (metainfo.xml)
  - Define service
  - Update dependencies
- [x] Alerts
- [x] Configuration
  - User-modifiable
  - Automatically determined
- [x] Kerberos
- [x] Script (install/start/stop)
- [x] Theme
