### PR TITLE
Set cdap_auth_heapsize properly

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -178,7 +178,8 @@ export OPTS="${OPTS} -Dhdp.version=${HDP_VERSION:-{{hdp_version}}} -Djava.securi
 export OPTS="${OPTS} -Dhdp.version=${HDP_VERSION:-{{hdp_version}}}"
 {% endif %}
 export TEZ_HOME="/usr/hdp/{{hdp_version}}/tez"
-export TEZ_CONF_DIR="/etc/tez/conf"</value>
+export TEZ_CONF_DIR="/etc/tez/conf"
+    </value>
     <display-name>Contents of cdap-env.sh</display-name>
     <value-attributes>
       <overridable>false</overridable>

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -53,6 +53,7 @@ else:
 cdap_user = config['configurations']['cdap-env']['cdap_user']
 log_dir = config['configurations']['cdap-env']['cdap_log_dir']
 pid_dir = config['configurations']['cdap-env']['cdap_pid_dir']
+cdap_auth_heapsize = config['configurations']['cdap-env']['cdap_auth_heapsize']
 cdap_kafka_heapsize = config['configurations']['cdap-env']['cdap_kafka_heapsize']
 cdap_master_heapsize = config['configurations']['cdap-env']['cdap_master_heapsize']
 cdap_router_heapsize = config['configurations']['cdap-env']['cdap_router_heapsize']


### PR DESCRIPTION
Without this line, the variable isn't populated, even though it shows up in the Ambari UI and is configured.
