### PR TITLE
Ambari service fixes

### DIFF
--- a/configuration/cdap-env.xml
+++ b/configuration/cdap-env.xml
@@ -20,7 +20,7 @@
 
   <property>
     <name>apt_repo_url</name>
-    <value>http://repository.cask.co/ubuntu/precise/amd64/cdap/3.4</value>
+    <value>http://repository.cask.co/ubuntu/precise/amd64/cdap/3.6</value>
     <description>
       URL to an APT repository hosting this version of CDAP. Defaults to
       the public Cask repository address
@@ -33,7 +33,7 @@
 
   <property>
     <name>yum_repo_url</name>
-    <value>http://repository.cask.co/centos/6/x86_64/cdap/3.4</value>
+    <value>http://repository.cask.co/centos/6/x86_64/cdap/3.6</value>
     <description>
       URL to a YUM repository hosting this version of CDAP. Defaults to
       the public Cask repository address
@@ -172,14 +172,14 @@ export AUTH_JAVA_HEAPMAX="-Xmx{{cdap_auth_heapsize}}"
 export KAFKA_JAVA_HEAPMAX="-Xmx{{cdap_kafka_heapsize}}"
 export MASTER_JAVA_HEAPMAX="-Xmx{{cdap_master_heapsize}}"
 export ROUTER_JAVA_HEAPMAX="-Xmx{{cdap_router_heapsize}}"
+export SPARK_HOME="/usr/hdp/{{hdp_version}}/spark"
 {% if kerberos_enabled %}
 export OPTS="${OPTS} -Dhdp.version=${HDP_VERSION:-{{hdp_version}}} -Djava.security.auth.login.config={{master_jaas_config_file}}"
 {% else %}
 export OPTS="${OPTS} -Dhdp.version=${HDP_VERSION:-{{hdp_version}}}"
 {% endif %}
 export TEZ_HOME="/usr/hdp/{{hdp_version}}/tez"
-export TEZ_CONF_DIR="/etc/tez/conf"
-    </value>
+export TEZ_CONF_DIR="/etc/tez/conf"</value>
     <display-name>Contents of cdap-env.sh</display-name>
     <value-attributes>
       <overridable>false</overridable>

--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -539,8 +539,8 @@
     <value>
       co.cask.cdap.data2.transaction.snapshot.SnapshotCodecV1,
       co.cask.cdap.data2.transaction.snapshot.SnapshotCodecV2,
-      co.cask.tephra.snapshot.SnapshotCodecV3,
-      co.cask.tephra.snapshot.SnapshotCodecV4
+      org.apache.tephra.snapshot.SnapshotCodecV3,
+      org.apache.tephra.snapshot.SnapshotCodecV4
     </value>
     <description>Specifies the class names of all supported transaction state codecs</description>
   </property>

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -55,7 +55,8 @@ def cdap_config(name=None):
         params.cdap_conf_dir,
         owner=params.cdap_user,
         group=params.user_group,
-        recursive=True
+        recursive=True,
+        create_parents=True
     )
 
     XmlConfig(

--- a/package/scripts/ambari_helpers.py
+++ b/package/scripts/ambari_helpers.py
@@ -51,12 +51,9 @@ def cdap_config(name=None):
         mode=0755
     )
 
-    Directory(
-        params.cdap_conf_dir,
-        owner=params.cdap_user,
-        group=params.user_group,
-        recursive=True,
-        create_parents=True
+    # Why don't we use Directory here? A: parameters changed between Ambari minor versions
+    Execute(
+        "mkdir -p %s && chown %s:%s %s" % (params.cdap_conf_dir, params.cdap_user, params.user_group, params.cdap_conf_dir)
     )
 
     XmlConfig(

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -60,12 +60,9 @@ class Kafka(Script):
         env.set_params(params)
         helpers.cdap_config('kafka')
 
-        Directory(
-            params.kafka_log_dir,
-            owner=params.cdap_user,
-            group=params.user_group,
-            recursive=True,
-            create_parents=True
+        # Why don't we use Directory here? A: parameters changed between Ambari minor versions
+        Execute(
+            "mkdir -p %s && chown %s:%s %s" % (params.kafka_log_dir, params.cdap_user, params.user_group, params.kafka_log_dir)
         )
 
 if __name__ == "__main__":

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -64,7 +64,8 @@ class Kafka(Script):
             params.kafka_log_dir,
             owner=params.cdap_user,
             group=params.user_group,
-            recursive=True
+            recursive=True,
+            create_parents=True
         )
 
 if __name__ == "__main__":

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -35,20 +35,20 @@ user_group = config['configurations']['cluster-env']['user_group']
 hdp_version = helpers.get_hdp_version()
 hadoop_lib_home = helpers.get_hadoop_lib()
 
-if distribution.startswith('centos') or distribution.startswith('redhat'):
-    os_repo_dir = '/etc/yum.repos.d/'
-    repo_file = 'cdap.repo'
-    package_mgr = 'yum'
-    key_cmd = "rpm --import %s/pubkey.gpg" % (files_dir)
-    cache_cmd = 'yum makecache'
-    repo_url = config['configurations']['cdap-env']['yum_repo_url']
-else:
+if distribution.startswith('debian') or distribution.startswith('ubuntu'):
     os_repo_dir = '/etc/apt/sources.list.d/'
     repo_file = 'cdap.list'
     package_mgr = 'apt-get'
     key_cmd = "apt-key add %s/pubkey.gpg" % (files_dir)
     cache_cmd = 'apt-get update'
     repo_url = config['configurations']['cdap-env']['apt_repo_url']
+else:
+    os_repo_dir = '/etc/yum.repos.d/'
+    repo_file = 'cdap.repo'
+    package_mgr = 'yum'
+    key_cmd = "rpm --import %s/pubkey.gpg" % (files_dir)
+    cache_cmd = 'yum makecache'
+    repo_url = config['configurations']['cdap-env']['yum_repo_url']
 
 cdap_user = config['configurations']['cdap-env']['cdap_user']
 log_dir = config['configurations']['cdap-env']['cdap_log_dir']


### PR DESCRIPTION
Same as #122 and #125 for `release/3.6` branch
- Fix repository URLs and set SPARK_HOME always
- Reverse logic on determining distribution
- Clean up whitespace so file displays in UI
- Use `mkdir` over `Directory` function
- Use `org.apache.tephra` classes
