### PR TITLE
CDAP-8023 UI port should be 11011 for CDAP under Ambari

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -2663,7 +2663,7 @@
 
   <property>
     <name>dashboard.bind.port</name>
-    <value>9999</value>
+    <value>11011</value>
     <description>
       CDAP UI bind port
     </description>


### PR DESCRIPTION
This fixes the default to match CDAP 4.0's port.