### PR TITLE
Remove version from repo definition

### DIFF
--- a/package/files/cdap.repo
+++ b/package/files/cdap.repo
@@ -1,4 +1,4 @@
-[CDAP-3.4]
+[CDAP]
 name=Cask Data Application Platform Packages
 baseurl=REPO_URL
 enabled=1


### PR DESCRIPTION
This is a display-only problem, but still something that could appear in logs, so removing it.