### PR TITLE
CDAP-8083 Don't toggle security.enabled with kerberos.auth.enabled

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -2379,12 +2379,6 @@
       </entries>
       <selection-cardinality>1</selection-cardinality>
     </value-attributes>
-    <depends-on>
-      <property>
-        <type>cdap-site</type>
-        <name>kerberos.auth.enabled</name>
-      </property>
-    </depends-on>
   </property>
 
   <property>


### PR DESCRIPTION
This prevents `security.enabled` from being automatically set to true on Kerberos clusters. This allows CDAP to be deployed onto a Kerberos-enabled cluster without enabling CDAP Security, which requires user configuration.