### PR TITLE
Revert "CDAP-8083 Don't toggle security.enabled with kerberos.auth.enabled"

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -2381,6 +2381,12 @@
       </entries>
       <selection-cardinality>1</selection-cardinality>
     </value-attributes>
+    <depends-on>
+      <property>
+        <type>cdap-site</type>
+        <name>kerberos.auth.enabled</name>
+      </property>
+    </depends-on>
   </property>
 
   <property>


### PR DESCRIPTION
Reverts caskdata/cdap-ambari-service#156

I thought that there was an error in the service, but it was another piece of automation that I was writing that was force-enabling security.