### PR TITLE
CDAP-8158 Fix Quicklinks if external SSL enabled

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -2675,17 +2675,17 @@
 
   <property>
     <name>dashboard.server.address</name>
-    <value>{{cdap_ui_host}}</value>
+    <value>{{cdap_ui_host}}:${dashboard.bind.port}</value>
     <description>
-      Address for CDAP UI
+      Address and port for clients to connect to the CDAP UI
     </description>
   </property>
 
   <property>
     <name>dashboard.ssl.server.address</name>
-    <value>{{cdap_ui_host}}</value>
+    <value>{{cdap_ui_host}}:${dashboard.ssl.bind.port}</value>
     <description>
-      Address for CDAP UI over SSL
+      Address and port for clients to connect to the CDAP UI over SSL
     </description>
   </property>
 

--- a/quicklinks/quicklinks.json
+++ b/quicklinks/quicklinks.json
@@ -24,7 +24,7 @@
           "type": "https",
           "checks": [
             {
-              "property": "ssl.enabled",
+              "property": "ssl.external.enabled",
               "desired": "true",
               "site": "cdap-site"
             }


### PR DESCRIPTION
The change to these properties doesn't affect CDAP, since these properties are only used for the Quick Links in Ambari.

Fixes CDAP-8158