### PR TITLE
CDAP-8224 Split cdap_user and cdap_hdfs_user and use cdap_hdfs_user for hdfs.user

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2015-2016 Cask Data, Inc.
+  Copyright © 2015-2017 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -38,7 +38,7 @@
 
   <property>
     <name>hdfs.user</name>
-    <value>{{cdap_user}}</value>
+    <value>{{cdap_hdfs_user}}</value>
     <description>User name for accessing HDFS</description>
   </property>
 

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -41,9 +41,12 @@ class Master(Script):
         import status_params
         env.set_params(params)
         self.configure(env)
-        helpers.create_hdfs_dir(params.hdfs_namespace, params.cdap_user, 775)
+        helpers.create_hdfs_dir(params.hdfs_namespace, params.cdap_hdfs_user, 775)
         # Create user's HDFS home
         helpers.create_hdfs_dir('/user/' + params.cdap_user, params.cdap_user, 775)
+        if cdap_hdfs_user != cdap_user:
+            helpers.create_hdfs_dir('/user/' + params.cdap_hdfs_user, params.cdap_hdfs_user, 775)
+
         # Hack to work around CDAP-1967
         self.remove_jackson(env)
         daemon_cmd = format('/opt/cdap/master/bin/cdap master start')

--- a/package/scripts/params.py
+++ b/package/scripts/params.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright © 2015-2016 Cask Data, Inc.
+# Copyright © 2015-2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -92,10 +92,12 @@ if kerberos_enabled:
     kinit_cmd = format("{kinit_path_local} -kt {cdap_user_keytab} {cdap_principal_name};")
     kinit_cmd_hdfs = format("{kinit_path_local} -kt {hdfs_user_keytab} {hdfs_principal_name};")
     kinit_cmd_master = format("{kinit_path_local} -kt {master_keytab_path} {master_jaas_princ};")
+    cdap_hdfs_user = cdap_user
 else:
     kinit_cmd = ""
     kinit_cmd_hdfs = ""
     kinit_cmd_master = ""
+    cdap_hdfs_user = "yarn"
 
 # Get ZooKeeper variables
 zk_client_port = str(default('/configurations/zoo.cfg/clientPort', None))


### PR DESCRIPTION
This sets the `cdap_hdfs_user` variable and sets it to either `cdap_user` or "yarn" if not running under Kerberos. This is due to an issue with YARN where DefaultContainerExecutor will always launch applications as `yarn` user to match the configuration required in our documentation.