### PR TITLE
Version bump to 4.0.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-PACKAGE_VERSION=${PACKAGE_VERSION:-4.0.1-SNAPSHOT}
+PACKAGE_VERSION=${PACKAGE_VERSION:-4.0.2}
 PACKAGE_ITERATION=${PACKAGE_ITERATION:-1}
 PACKAGE_FORMATS=${PACKAGE_FORMATS:-deb rpm}
 
-LICENSE="Copyright © 2015-2016 Cask Data, Inc. Licensed under the Apache License, Version 2.0."
+LICENSE="Copyright © 2015-2017 Cask Data, Inc. Licensed under the Apache License, Version 2.0."
 RPM_FPM_ARGS="-t rpm --rpm-os linux"
 DEB_FPM_ARGS="-t deb"
 


### PR DESCRIPTION
Skipping `4.0.1` as unreleased because we accidentally released a snapshot version to the release repository and snapshot versions are higher than non-snapshot versions, to match the Java versioning scheme of CDAP.