### PR TITLE
Require SPARK, for clients for Hive/Spark/Tez on Master

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -375,10 +375,11 @@
       <requiredServices>
         <service>HBASE</service>
         <service>HDFS</service>
-        <service>YARN</service>
-        <service>ZOOKEEPER</service>
         <service>HIVE</service>
         <service>SPARK</service>
+        <service>TEZ</service>
+        <service>YARN</service>
+        <service>ZOOKEEPER</service>
       </requiredServices>
 
       <!-- names for config files (under configuration dir) -->

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-   Copyright © 2015-2016 Cask Data, Inc.
+   Copyright © 2015-2017 Cask Data, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License"); you may not
    use this file except in compliance with the License. You may obtain a copy of
@@ -175,20 +175,6 @@
             </dependency>
             <dependency>
               <name>HIVE/HIVE_CLIENT</name>
-              <scope>host</scope>
-              <auto-deploy>
-                <enabled>true</enabled>
-              </auto-deploy>
-            </dependency>
-            <dependency>
-              <name>TEZ/TEZ_CLIENT</name>
-              <scope>host</scope>
-              <auto-deploy>
-                <enabled>true</enabled>
-              </auto-deploy>
-            </dependency>
-            <dependency>
-              <name>SPARK/SPARK_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>
@@ -376,8 +362,6 @@
         <service>HBASE</service>
         <service>HDFS</service>
         <service>HIVE</service>
-        <service>SPARK</service>
-        <service>TEZ</service>
         <service>YARN</service>
         <service>ZOOKEEPER</service>
       </requiredServices>

--- a/metainfo.xml
+++ b/metainfo.xml
@@ -173,6 +173,27 @@
                 <enabled>true</enabled>
               </auto-deploy>
             </dependency>
+            <dependency>
+              <name>HIVE/HIVE_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>TEZ/TEZ_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+            <dependency>
+              <name>SPARK/SPARK_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
           </dependencies>
         </component>
 
@@ -357,6 +378,7 @@
         <service>YARN</service>
         <service>ZOOKEEPER</service>
         <service>HIVE</service>
+        <service>SPARK</service>
       </requiredServices>
 
       <!-- names for config files (under configuration dir) -->

--- a/stacks/HDP/2.2/services/CDAP/metainfo.xml
+++ b/stacks/HDP/2.2/services/CDAP/metainfo.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+<metainfo>
+  <schemaVersion>2.0</schemaVersion>
+  <services>
+    <service>
+      <name>CDAP</name>
+
+      <components>
+        <component>
+          <name>CDAP_MASTER</name>
+          <dependencies>
+            <dependency>
+              <name>SPARK/SPARK_CLIENT</name>
+              <scope>host</scope>
+              <auto-deploy>
+                <enabled>true</enabled>
+              </auto-deploy>
+            </dependency>
+          </dependencies>
+        </component>
+      </components>
+      <configuration-dependencies>
+        <config-type>spark-env</config-type>
+      </configuration-dependencies>
+    </service>
+  </services>
+</metainfo>


### PR DESCRIPTION
Install clients for Hive, Spark, and Tez using Ambari's built-in capabilities. Also, require SPARK since Ambari doesn't have optional dependencies.