### PR TITLE
CDAP-9003 Increase Explore memory

### DIFF
--- a/configuration/cdap-site.xml
+++ b/configuration/cdap-site.xml
@@ -835,7 +835,7 @@
 
   <property>
     <name>explore.executor.container.memory.mb</name>
-    <value>1024</value>
+    <value>2048</value>
     <description>
       Memory in megabytes for each CDAP Explore executor instance. This is
       explicitly set differently than ${master.service.memory.mb} as Explore


### PR DESCRIPTION
Set default to 2048, which is what is used in the CSD.