### PR TITLE
update mapreduce dependency

### DIFF
--- a/metainfo.xml
+++ b/metainfo.xml
@@ -146,7 +146,7 @@
               </auto-deploy>
             </dependency>
             <dependency>
-              <name>YARN/MAPREDUCE2_CLIENT</name>
+              <name>MAPREDUCE2/MAPREDUCE2_CLIENT</name>
               <scope>host</scope>
               <auto-deploy>
                 <enabled>true</enabled>


### PR DESCRIPTION
Update the dependency name YARN/MAPREDUCE2_CLIENT to MAPREDUCE2/MAPREDUCE2_CLIENT. This will cause failures while installing CDAP in Ambari 2.5.0.3.  

https://issues.cask.co/browse/CDAP-9276