### PR TITLE
Update SSL checks for Ambari

### DIFF
--- a/alerts.json
+++ b/alerts.json
@@ -57,8 +57,8 @@
     ],
     "CDAP_UI": [
       {
-        "name": "cdap_ui_process",
-        "label": "CDAP UI Process",
+        "name": "cdap_ui_port",
+        "label": "CDAP UI Port",
         "description": "This alert is triggered if the CDAP UI processes cannot be confirmed to be up and listening on the network for the configured critical threshold, given in seconds.",
         "interval": 1,
         "scope": "ANY",
@@ -66,10 +66,10 @@
         "source": {
           "type": "WEB",
           "uri": {
-            "http": "{{hostname}}:{{cdap-site/dashboard.bind.port}}",
-            "https": "{{hostname}}:{{cdap-site/dashboard.ssl.bind.port}}",
+            "http": "{{cdap-site/dashboard.bind.port}}",
+            "https": "{{cdap-site/dashboard.ssl.bind.port}}",
             "https_property": "{{cdap-site/ssl.external.enabled}}",
-            "https_property_value": "true",
+            "https_property_value": true,
             "default_port": 11011,
             "connection_timeout": 5.0
           },
@@ -86,6 +86,18 @@
               "value": 5.0
             }
           }
+        }
+      },
+      {
+        "name": "cdap_ui_process",
+        "label": "CDAP UI Process",
+        "description": "This alert is triggered if the CDAP UI processes cannot be confirmed to be up.",
+        "interval": 1,
+        "scope": "ANY",
+        "enabled": true,
+        "source": {
+          "type": "SCRIPT",
+          "path": "CDAP/3.6.0-SNAPSHOT/package/alerts/alert_cdap_ui_status.py"
         }
       }
     ],

--- a/package/alerts/alert_cdap_ui_status.py
+++ b/package/alerts/alert_cdap_ui_status.py
@@ -1,0 +1,37 @@
+# coding=utf8
+# Copyright © 2016-2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+import logging
+
+from resource_management import *
+
+RESULT_STATE_OK = 'OK'
+RESULT_STATE_CRITICAL = 'CRITICAL'
+RESULT_STATE_UNKNOWN = 'UNKNOWN'
+
+LOGGER_EXCEPTION_MESSAGE = "[Alert] CDAP UI Health on {0} fails:"
+logger = logging.getLogger('ambari_alerts')
+
+
+def execute(configurations={}, parameters={}, host_name=None):
+    if configurations is None:
+        return (RESULT_STATE_UNKNOWN, ['There were no configurations supplied to the script.'])
+    try:
+        check_cmd = format('service cdap-ui status')
+        Execute(check_cmd, timeout=5)
+        return(RESULT_STATE_OK, ['UI OK - CDAP UI is running'])
+    except:
+        return(RESULT_STATE_CRITICAL, [LOGGER_EXCEPTION_MESSAGE])

--- a/quicklinks/quicklinks.json
+++ b/quicklinks/quicklinks.json
@@ -3,7 +3,14 @@
   "description": "Quick Links for CDAP services",
   "configuration": {
     "protocol": {
-      "type":"HTTP_ONLY"
+      "type": "https",
+      "checks": [
+        {
+          "property": "ssl.external.enabled",
+          "desired": "true",
+          "site": "cdap-site"
+        }
+      ]
     },
     "links": [
       {
@@ -19,16 +26,6 @@
           "https_default_port": "9443",
           "regex": "\\w*:(\\d+)",
           "site": "cdap-site"
-        },
-        "protocol": {
-          "type": "https",
-          "checks": [
-            {
-              "property": "ssl.external.enabled",
-              "desired": "true",
-              "site": "cdap-site"
-            }
-          ]
         }
       }
     ]


### PR DESCRIPTION
This fixes the SSL checks for the Ambari service and adds a process check on the UI. This allows us to differentiate between the process not being up, and the process not responding.