### PR TITLE
CDAP-9393 check status before stopping

### DIFF
--- a/package/scripts/auth.py
+++ b/package/scripts/auth.py
@@ -49,10 +49,17 @@ class Auth(Script):
 
     def stop(self, env):
         print('Stop the CDAP Auth Server')
-        Execute('service cdap-auth-server stop')
+        import status_params
+        daemon_cmd = format('service cdap-auth-server stop')
+        no_op_test = format('ls {status_params.cdap_auth_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_auth_pid_file}) >/dev/null 2>&1')
+        Execute(
+            daemon_cmd,
+            only_if=no_op_test
+        )
 
     def status(self, env):
-        Execute('service cdap-auth-server status')
+        import status_params
+        check_process_status(status_params.cdap_auth_pid_file)
 
     def configure(self, env):
         print('Configure the CDAP Auth Server')

--- a/package/scripts/kafka.py
+++ b/package/scripts/kafka.py
@@ -49,10 +49,17 @@ class Kafka(Script):
 
     def stop(self, env):
         print('Stop the CDAP Kafka Server')
-        Execute('service cdap-kafka-server stop')
+        import status_params
+        daemon_cmd = format('service cdap-kafka-server stop')
+        no_op_test = format('ls {status_params.cdap_kafka_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_kafka_pid_file}) >/dev/null 2>&1')
+        Execute(
+            daemon_cmd,
+            only_if=no_op_test
+        )
 
     def status(self, env):
-        Execute('service cdap-kafka-server status')
+        import status_params
+        check_process_status(status_params.cdap_kafka_pid_file)
 
     def configure(self, env):
         print('Configure the CDAP Kafka Server')

--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -59,10 +59,17 @@ class Master(Script):
 
     def stop(self, env):
         print('Stop the CDAP Master')
-        Execute('service cdap-master stop')
+        import status_params
+        daemon_cmd = format('service cdap-master stop')
+        no_op_test = format('ls {status_params.cdap_master_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_master_pid_file}) >/dev/null 2>&1')
+        Execute(
+            daemon_cmd,
+            only_if=no_op_test
+        )
 
     def status(self, env):
-        Execute('service cdap-master status')
+        import status_params
+        check_process_status(status_params.cdap_master_pid_file)
 
     def configure(self, env):
         print('Configure the CDAP Master')

--- a/package/scripts/router.py
+++ b/package/scripts/router.py
@@ -49,10 +49,17 @@ class Router(Script):
 
     def stop(self, env):
         print('Stop the CDAP Router')
-        Execute('service cdap-router stop')
+        import status_params
+        daemon_cmd = format('service cdap-router stop')
+        no_op_test = format('ls {status_params.cdap_router_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_router_pid_file}) >/dev/null 2>&1')
+        Execute(
+            daemon_cmd,
+            only_if=no_op_test
+        )
 
     def status(self, env):
-        Execute('service cdap-router status')
+        import status_params
+        check_process_status(status_params.cdap_router_pid_file)
 
     def configure(self, env):
         print('Configure the CDAP Router')

--- a/package/scripts/ui.py
+++ b/package/scripts/ui.py
@@ -49,10 +49,17 @@ class UI(Script):
 
     def stop(self, env):
         print('Stop the CDAP UI')
-        Execute('service cdap-ui stop')
+        import status_params
+        daemon_cmd = format('service cdap-ui stop')
+        no_op_test = format('ls {status_params.cdap_ui_pid_file} >/dev/null 2>&1 && ps -p $(<{status_params.cdap_ui_pid_file}) >/dev/null 2>&1')
+        Execute(
+            daemon_cmd,
+            only_if=no_op_test
+        )
 
     def status(self, env):
-        Execute('service cdap-ui status')
+        import status_params
+        check_process_status(status_params.cdap_ui_pid_file)
 
     def configure(self, env):
         print('Configure the CDAP UI')


### PR DESCRIPTION
This fixes CDAP-9393. Check the status before stopping the service and adjust how we check the status to match other services.