### PR TITLE
CDAP-11445 Use unique headless principal per cluster

### DIFF
--- a/kerberos.json
+++ b/kerberos.json
@@ -12,7 +12,7 @@
         {
           "name": "cdap",
           "principal": {
-            "value": "cdap@${realm}",
+            "value": "${cdap-env/cdap_user}-${cluster_name|toLower()}@${realm}",
             "type" : "user",
             "configuration": "cdap-env/cdap_principal_name",
             "local_username": "cdap"


### PR DESCRIPTION
Use a unique headless user per cluster, to prevent us from invalidating other headless keytabs.