### PR TITLE
Remove restriction that CDAP must be running from run_class

### DIFF
--- a/package/scripts/master.py
+++ b/package/scripts/master.py
@@ -115,8 +115,7 @@ class Master(Script):
         cmd = format("/opt/cdap/master/bin/cdap run %s %s" % (classname, arguments))
         Execute(
             cmd,
-            user=params.cdap_user,
-            only_if=self.status(env)
+            user=params.cdap_user
         )
 
     def remove_jackson(self, env):


### PR DESCRIPTION
This would otherwise prevent `upgrade` or `upgrade_hbase` from running if the CDAP Master isn't running. This is incorrect behavior. Rather than add complex logic, simply removing the restriction.