### PR TITLE
Support stack Express Upgrade in CDAP service

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/config-upgrade.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/config-upgrade.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade-config-changes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-config.xsd">
+  <services>
+    <service name="CDAP">
+      <component name="CDAP_MASTER">
+        <changes>
+          <definition xsi:type="configure" id="cdap_master_ssl_external_enabled">
+            <type>cdap-site</type>
+            <set key="ssl.external.enabled" value="true" if-type="cdap-site" if-key="ssl.enabled" if-value="true"/>
+          </definition>
+        </changes>
+      </component>
+    </service>
+  </services>
+</upgrade-config-changes>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.3.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.3.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.3.*.*</target>
+  <target-stack>HDP-2.3</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.4.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.4.*.*</target>
+  <target-stack>HDP-2.4</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.5.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.6.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/config-upgrade.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/config-upgrade.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade-config-changes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-config.xsd">
+  <services>
+    <service name="CDAP">
+      <component name="CDAP_MASTER">
+        <changes>
+          <definition xsi:type="configure" id="cdap_master_ssl_external_enabled">
+            <type>cdap-site</type>
+            <set key="ssl.external.enabled" value="true" if-type="cdap-site" if-key="ssl.enabled" if-value="true"/>
+          </definition>
+        </changes>
+      </component>
+    </service>
+  </services>
+</upgrade-config-changes>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.4.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.4.*.*</target>
+  <target-stack>HDP-2.4</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.5.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.6.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/config-upgrade.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/config-upgrade.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade-config-changes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-config.xsd">
+  <services>
+    <service name="CDAP">
+      <component name="CDAP_MASTER">
+        <changes>
+          <definition xsi:type="configure" id="cdap_master_ssl_external_enabled">
+            <type>cdap-site</type>
+            <set key="ssl.external.enabled" value="true" if-type="cdap-site" if-key="ssl.enabled" if-value="true"/>
+          </definition>
+        </changes>
+      </component>
+    </service>
+  </services>
+</upgrade-config-changes>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.5.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.6.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/config-upgrade.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/config-upgrade.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade-config-changes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-config.xsd">
+  <services>
+    <service name="CDAP">
+      <component name="CDAP_MASTER">
+        <changes>
+          <definition xsi:type="configure" id="cdap_master_ssl_external_enabled">
+            <type>cdap-site</type>
+            <set key="ssl.external.enabled" value="true" if-type="cdap-site" if-key="ssl.enabled" if-value="true"/>
+          </definition>
+        </changes>
+      </component>
+    </service>
+  </services>
+</upgrade-config-changes>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/nonrolling-upgrade-2.6.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>NON_ROLLING</type>
+  <!-- TODO: figure out prerequisite-checks -->
+  <order>
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <skippable>true</skippable>
+      <service-check>false</service-check>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <!-- CDAP -->
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <parallel-scheduler/>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CLIENTS</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        </pre-upgrade>
+        <pre-downgrade /> # do not change config on downgrade
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>


### PR DESCRIPTION
This is just a framework for the upgrade. This will handle CDAP's lifecycle and running upgrade tool on a cluster (stack) upgrade. This only supports the "express" upgrade, where everything gets shut down.