### PR TITLE
Rewrite copied+pasted sections and pass XSD validation

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.3.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.3.*.*</target>
   <target-stack>HDP-2.3</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.4.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.4.*.*</target>
   <target-stack>HDP-2.4</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.5.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.5.*.*</target>
   <target-stack>HDP-2.5</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.6.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.6.*.*</target>
   <target-stack>HDP-2.6</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.4.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.4.*.*</target>
   <target-stack>HDP-2.4</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.5.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.5.*.*</target>
   <target-stack>HDP-2.5</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.6.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.6.*.*</target>
   <target-stack>HDP-2.6</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.5.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.5.*.*</target>
   <target-stack>HDP-2.5</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.6.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.6.*.*</target>
   <target-stack>HDP-2.6</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/nonrolling-upgrade-2.6.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
    Copyright © 2017 Cask Data, Inc.
 
@@ -19,23 +19,22 @@
   <target>2.6.*.*</target>
   <target-stack>HDP-2.6</target-stack>
   <type>NON_ROLLING</type>
-  <!-- TODO: figure out prerequisite-checks -->
   <order>
-    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre {{direction.text.proper}}">
-      <add-after-group-entry>YARN</add-after-group-entry>
-      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
-        <task xsi:type="manual">
-          <message>Before continuing, please stop all running CDAP applications in all CDAP namespaces.</message>
-        </task>
-      </execute-stage>
-    </group>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>YARN</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
 
     <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
-      <add-after-group>PRE_CLUSTER</add-after-group>
-      <skippable>true</skippable>
       <service-check>false</service-check>
+      <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-
+      <add-after-group>PRE_CLUSTER</add-after-group>
       <service name="CDAP">
         <component>CDAP_UI</component>
         <component>CDAP_MASTER</component>
@@ -46,10 +45,9 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
-      <add-after-group-entry>TEZ</add-after-group-entry>
-      <!-- CDAP -->
+      <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
-        <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
       </execute-stage>
     </group>
 
@@ -64,11 +62,10 @@
     </group>
 
     <group xsi:type="restart" name="CDAP" title="CDAP">
-      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <parallel-scheduler/>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>
@@ -101,9 +98,9 @@
       </component>
       <component name="CDAP_MASTER">
         <pre-upgrade>
-          <task xsi:type="configure" id="cdap_master_ssl_external_enabled"/>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
         </pre-upgrade>
-        <pre-downgrade /> # do not change config on downgrade
+        <pre-downgrade /> <!-- do not change config on downgrade -->
         <upgrade>
           <task xsi:type="restart-task" />
         </upgrade>


### PR DESCRIPTION
Update the Express Upgrade configuration files to pass XSD validation.

I'm not sure exactly what happened, but I had copied these sections from the Ambari documentation and I suspect that there's a non-ASCII quote in it somewhere. At any rate, set encoding to UTF-8 explicitly and retyped those sections by hand. This has fixed the Ambari Server startup.

You can validate the XML files using `xmllint` and the [schema file](https://raw.githubusercontent.com/apache/ambari/branch-2.5/ambari-server/src/main/resources/upgrade-pack.xsd) from Ambari.

```bash
cd /tmp
curl -O https://raw.githubusercontent.com/apache/ambari/branch-2.5/ambari-server/src/main/resources/upgrade-pack.xsd
curl -O https://raw.githubusercontent.com/apache/ambari/branch-2.5/ambari-server/src/main/resources/upgrade-config.xsd
xmllint --noout --schema upgrade-pack.xsd src/main/resources/common-services/CDAP/upgrades/HDP/2.*/non*.xml
xmllint --noout --schema upgrade-config.xsd src/main/resources/common-services/CDAP/upgrades/HDP/2.*/config-upgrade.xml
```

The previous code worked fine on Ambari 2.4, which didn't do actual XSD validation of the XML. That was added with [AMBARI-18232](https://issues.apache.org/jira/browse/AMBARI-18232) in Ambari 2.5 and later.