### PR TITLE
Add missing add-after-group property

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.3.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.3.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.4.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.5.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/nonrolling-upgrade-2.6.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.4.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.5.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/nonrolling-upgrade-2.6.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.5.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/nonrolling-upgrade-2.6.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/nonrolling-upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/nonrolling-upgrade-2.6.xml
@@ -45,6 +45,7 @@
     </group>
 
     <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>UPDATE_DESIRED_STACK_ID</add-after-group>
       <add-after-group-entry>TEZ</add-after-group-entry>
       <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
         <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />


### PR DESCRIPTION
Otherwise, Ambari server fails to load the upgrade files. Tested on Ambari 2.5 (only one which does validation of XML) with both HDP 2.6 (startup) and HDP 2.4 (startup and upgrade to 2.5, then 2.6) clusters.