### PR TITLE
Put access logging on main Settings page

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-logback.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-logback.xml
@@ -33,6 +33,20 @@
       <type>boolean</type>
       <overridable>false</overridable>
     </value-attributes>
+    <value-attributes>
+      <type>value-list</type>
+      <entries>
+        <entry>
+          <value>true</value>
+          <label>Enabled</label>
+        </entry>
+        <entry>
+          <value>false</value>
+          <label>Disabled</label>
+        </entry>
+      </entries>
+      <selection-cardinality>1</selection-cardinality>
+    </value-attributes>
   </property>
 
   <property>

--- a/src/main/resources/common-services/CDAP/4.0.0/themes/theme.json
+++ b/src/main/resources/common-services/CDAP/4.0.0/themes/theme.json
@@ -162,6 +162,10 @@
           "subsection-name": "subsection-yarn-services-mem"
         },
         {
+          "config": "cdap-logback/access_logging",
+          "subsection-name": "subsection-cdap-features-col1"
+        },
+        {
           "config": "cdap-site/audit.enabled",
           "subsection-name": "subsection-cdap-features-col1"
         },


### PR DESCRIPTION
This adds "Enable Access Logging" to the main "Settings" page for CDAP in Ambari.