### PR TITLE
CDAP-11440 Use Ambari custom repos

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/package/scripts/ambari_helpers.py
+++ b/src/main/resources/common-services/CDAP/4.0.0/package/scripts/ambari_helpers.py
@@ -37,7 +37,14 @@ def package(name):
 def add_repo(source, dest):
     import params
     dest_file = dest + params.repo_file
-    Execute("sed -e 's#REPO_URL#%s#' %s > %s" % (params.repo_url, source, dest_file))
+    # Remove previous dest_file always
+    Execute("rm -f %s" % (dest_file))
+    # Skip sed if CDAP repos exist, we're on a newer Ambari... yay!
+    no_op_test = format('ls {dest} 2>/dev/null | grep CDAP >/dev/null 2>&1')
+    Execute(
+        "sed -e 's#REPO_URL#%s#' %s > %s" % (params.repo_url, source, dest_file),
+        not_if=no_op_test
+    )
     Execute(params.key_cmd)
     Execute(params.cache_cmd)
 

--- a/src/main/resources/stacks/HDP/2.0.6/services/CDAP/repos/repoinfo.xml
+++ b/src/main/resources/stacks/HDP/2.0.6/services/CDAP/repos/repoinfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+   Copyright © 2015-2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+<reposinfo>
+  <os family="redhat6">
+    <repo>
+      <baseurl>http://repository.cask.co/centos/6/x86_64/cdap/4.2</baseurl>
+      <repoid>CDAP-4.2</repoid>
+      <reponame>CDAP</reponame>
+    </repo>
+  </os>
+  <os family="redhat7">
+    <repo>
+      <baseurl>http://repository.cask.co/centos/6/x86_64/cdap/4.2</baseurl>
+      <repoid>CDAP-4.2</repoid>
+      <reponame>CDAP</reponame>
+    </repo>
+  </os>
+  <os family="ubuntu12">
+    <repo>
+      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</baseurl>
+      <repoid>CDAP-4.2</repoid>
+      <reponame>CDAP</reponame>
+    </repo>
+  </os>
+  <os family="ubuntu14">
+    <repo>
+      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</baseurl>
+      <repoid>CDAP-4.2</repoid>
+      <reponame>CDAP</reponame>
+    </repo>
+  </os>
+  <os family="ubuntu16">
+    <repo>
+      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</baseurl>
+      <repoid>CDAP-4.2</repoid>
+      <reponame>CDAP</reponame>
+    </repo>
+  </os>
+</reposinfo>


### PR DESCRIPTION
This adds support for installing our repository using Ambari's repository capabilities for custom services ([AMBARI-15538](https://issues.apache.org/jira/browse/AMBARI-15538)). However, since this support was only added in Ambari 2.4.2 and we support Ambari 2.2, we have to include a hack to check for the presence of the service from Ambari so we don't write out our own.