### PR TITLE
add rolling upgrade

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.3.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.3.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.3.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.3.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.3.*.*</target>
+  <target-stack>HDP-2.3</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.4.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.4.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.4.*.*</target>
+  <target-stack>HDP-2.4</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.5.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.5.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.6.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.3/upgrade-2.6.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.4.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.4.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.4.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.4.*.*</target>
+  <target-stack>HDP-2.4</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.5.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.5.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.6.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.4/upgrade-2.6.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.5.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.5.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.5.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.5.*.*</target>
+  <target-stack>HDP-2.5</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.6.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.5/upgrade-2.6.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/upgrade-2.6.xml
@@ -66,7 +66,7 @@
       <service-check>false</service-check>
       <skippable>true</skippable>
       <supports-auto-skip-failure>false</supports-auto-skip-failure>
-      <add-after-group>Upgrade service configs</add-after-group>
+      <add-after-group>CDAP_UPGRADE_TOOL</add-after-group>
 
       <service name="CDAP">
         <component>CDAP_UI</component>

--- a/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/upgrade-2.6.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/upgrades/HDP/2.6/upgrade-2.6.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright © 2017 Cask Data, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+-->
+
+<upgrade xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="upgrade-pack.xsd">
+  <target>2.6.*.*</target>
+  <target-stack>HDP-2.6</target-stack>
+  <type>ROLLING</type>
+  <order>
+
+    <group xsi:type="cluster" name="PRE_CLUSTER" title="Pre Upgrade">
+      <add-after-group-entry>HDFS</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Stop running CDAP applications">
+        <task xsi:type="manual">
+          <message>Before continuing, stop all CDAP applications and pipelines in all namespaces.</message>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="stop" name="STOP_CDAP_SERVICE_COMPONENTS" title="Stop CDAP components">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>PRE_CLUSTER</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="cluster" name="Upgrade service configs" title="Upgrade service configs">
+      <add-after-group>CLIENTS</add-after-group>
+      <add-after-group-entry>TEZ</add-after-group-entry>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Enable external SSL if configured">
+        <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+      </execute-stage>
+    </group>
+
+    <group xsi:type="cluster" name="CDAP_UPGRADE_TOOL" title="CDAP Upgrade">
+      <add-after-group>SPARK_CLIENTS</add-after-group>
+      <execute-stage service="CDAP" component="CDAP_MASTER" title="Run Upgrade Tool">
+        <task xsi:type="execute" hosts="master">
+          <script>scripts/master.py</script>
+          <function>upgrade</function>
+        </task>
+      </execute-stage>
+    </group>
+
+    <group xsi:type="restart" name="CDAP" title="CDAP">
+      <service-check>false</service-check>
+      <skippable>true</skippable>
+      <supports-auto-skip-failure>false</supports-auto-skip-failure>
+      <add-after-group>Upgrade service configs</add-after-group>
+
+      <service name="CDAP">
+        <component>CDAP_UI</component>
+        <component>CDAP_MASTER</component>
+        <component>CDAP_ROUTER</component>
+        <component>CDAP_KAFKA</component>
+        <component>CDAP_AUTH_SERVER</component>
+      </service>
+    </group>
+
+    <group xsi:type="restart" name="CDAP_CLIENT" title="Upgrade CDAP Clients">
+      <add-after-group>CDAP</add-after-group>
+      <service name="CDAP">
+        <component>CDAP_CLIENT</component>
+      </service>
+    </group>
+  </order>
+
+  <processing>
+    <service name="CDAP">
+      <component name="CDAP_AUTH_SERVER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_KAFKA">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_MASTER">
+        <pre-upgrade>
+          <task xsi:type="configure" id="cdap_master_ssl_external_enabled" />
+        </pre-upgrade>
+        <pre-downgrade /> <!-- do not change config on downgrade -->
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_ROUTER">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+      <component name="CDAP_UI">
+        <upgrade>
+          <task xsi:type="restart-task" />
+        </upgrade>
+      </component>
+    </service>
+  </processing>
+</upgrade>


### PR DESCRIPTION
Support rolling upgrades while running upgrade tool on a cluster (stack) upgrade. During the upgrade we shut CDAP down, the cluster gets upgraded, we run the upgrade tool and then restart CDAP. 