### PR TITLE
Remove 'messaging.system.topics' from ambari configuration cdap-site.xml.

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-site.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-site.xml
@@ -1421,17 +1421,6 @@
   </property>
 
   <property>
-    <name>messaging.system.topics</name>
-    <value>${audit.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${notification.topic}</value>
-    <description>A comma-separated list of topics that are always available in the system namespace.
-        Multiple topics sharing the same prefix and distinguished by different numerical suffixes
-        can be specified with the syntax &lt;common.prefix&gt;:&lt;total.topic.number&gt;,
-        where the &lt;total.topic.number&gt; is the total number of topics sharing the &lt;common.prefix&gt;,
-        and the numerical suffixes will range from 0 to (&lt;total.topic.number&gt; - 1).</description>
-    <display-name>Messaging System Topics</display-name>
-   </property>
-
-  <property>
     <name>messaging.table.expiration.seconds</name>
     <value>300</value>
     <description>


### PR DESCRIPTION
Remove 'messaging.system.topics' from ambari configuration cdap-site.xml.
In cdap-default.xml, we will mark it final: https://github.com/caskdata/cdap/pull/8910