### PR TITLE
add widget for access_logging

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/themes/theme.json
+++ b/src/main/resources/common-services/CDAP/4.0.0/themes/theme.json
@@ -465,6 +465,12 @@
             }
           ]
         }
+      },
+      {
+        "config": "cdap-logback/access_logging",
+        "widget": {
+        "type": "toggle"
+        }
       }
     ]
   }


### PR DESCRIPTION
The config "cdap-logback/access_logging" was defined in the theme under layout section but was missing from the widgets section. As a result, older versions of Ambari(<2.5) wouldn't load the main config page. Adding this widget loads the page. 