### PR TITLE
CDAP-12126

### DIFF
--- a/src/main/resources/common-services/CDAP/4.0.0/package/scripts/params.py
+++ b/src/main/resources/common-services/CDAP/4.0.0/package/scripts/params.py
@@ -47,7 +47,7 @@ else:
     repo_file = 'cdap.repo'
     package_mgr = 'yum'
     key_cmd = "rpm --import %s/pubkey.gpg" % (files_dir)
-    cache_cmd = 'yum makecache'
+    cache_cmd = 'yum --disablerepo=* --enablerepo=CDAP makecache'
     repo_url = config['configurations']['cdap-env']['yum_repo_url']
 
 cdap_user = config['configurations']['cdap-env']['cdap_user']


### PR DESCRIPTION
CDAP-12126 update the Ambari service to only run a makecache on the CDAP repo