### PR TITLE
CDAP-12235 Configuration changes for Ambari

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ to make CDAP an available service.
 
 Simply checkout the repository and run `./build.sh` to build the RPM and DEB packages. This
 will check out the CDAP service using the latest release of CDAP. Specific major/minor releases
-of CDAP can be obtained by pulling the corresponding branch. For example, for CDAP 4.2, you would
-checkout the `release/4.2` branch.
+of CDAP can be obtained by pulling the corresponding branch. For example, for CDAP 4.3, you would
+checkout the `release/4.3` branch.
 
 ### Installing packages
 

--- a/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-env.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-env.xml
@@ -20,7 +20,7 @@
 
   <property>
     <name>apt_repo_url</name>
-    <value>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</value>
+    <value>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.3</value>
     <description>
       URL to an APT repository hosting this version of CDAP. Defaults to
       the public Cask repository address
@@ -33,7 +33,7 @@
 
   <property>
     <name>yum_repo_url</name>
-    <value>http://repository.cask.co/centos/6/x86_64/cdap/4.2</value>
+    <value>http://repository.cask.co/centos/6/x86_64/cdap/4.3</value>
     <description>
       URL to a YUM repository hosting this version of CDAP. Defaults to
       the public Cask repository address

--- a/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-site.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-site.xml
@@ -1547,15 +1547,6 @@
   </property>
 
   <property>
-    <name>messaging.table.hbase.split.policy</name>
-    <value>org.apache.hadoop.hbase.regionserver.DisabledRegionSplitPolicy</value>
-    <description>
-      The class name that controls the HBase table region split policy.
-      Ideally, auto-splitting should be disabled for HBase tables used by the messaging system.
-    </description>
-  </property>
-
-  <property>
     <name>messaging.topic.default.ttl.seconds</name>
     <value>604800</value>
     <description>
@@ -1564,7 +1555,6 @@
   </property>
 
   <property>
-    <!-- Use lower heap memory ratio for the messaging service, since it uses non-heap memory for the connections -->
     <name>messaging.twill.java.heap.memory.ratio</name>
     <value>0.6</value>
     <description>
@@ -1573,7 +1563,6 @@
   </property>
 
   <property>
-    <!-- Use higher reserved memory setting for the messaging service, since it uses non-heap memory for connections -->
     <name>messaging.twill.java.reserved.memory.mb</name>
     <value>512</value>
     <description>
@@ -2122,6 +2111,73 @@
     <description>The type of retry policy for MapReduce programs. Allowed options: "none",
       "fixed.delay", or "exponential.backoff".</description>
     <display-name>MapReduce Retry Policy Type</display-name>
+  </property>
+
+  <property>
+    <name>program.message.retry.policy.base.delay.ms</name>
+    <value>1000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>program.message.retry.policy.max.delay.ms</name>
+    <value>3000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>program.message.retry.policy.max.retries</name>
+    <value>1000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>program.message.retry.policy.max.time.secs</name>
+    <value>600</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>program.message.retry.policy.type</name>
+    <value>fixed.delay</value>
+    <description>
+      The type of retry policy for programs. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
+    </description>
+    <value-attributes>
+      <type>value-list</type>
+      <entries>
+        <entry>
+          <value>fixed.delay</value>
+          <label>Fixed Delay</label>
+        </entry>
+        <entry>
+          <value>none</value>
+          <label>None</label>
+        </entry>
+        <entry>
+          <value>exponential.backoff</value>
+          <label>Exponential Backoff</label>
+        </entry>
+      </entries>
+      <selection-cardinality>1</selection-cardinality>
+    </value-attributes>
+  </property>
+
+  <property>
+    <name>program.status.event.topic</name>
+    <value>programstatusevent</value>
+    <description>
+      Topic name for publishing program status events from program runners to the messaging system
+    </description>
   </property>
 
   <property>
@@ -2958,26 +3014,6 @@
   </property>
 
   <property>
-    <name>security.authorization.admin.users</name>
-    <value></value>
-    <description>
-      A comma-separated list of users for whom admin privileges are to be
-      granted on the CDAP instance during CDAP startup, so that these users
-      can create namespaces. These users are also granted admin privileges
-      on the default namespace, so that they can manage privileges on the
-      default namespace. This provides a method to bootstrap CDAP on an
-      authorization-enabled cluster. The default is empty, in which case no
-      users have access to creating namespaces or to managing privileges on
-      the default namespace. In that scenario, authorization in CDAP has to
-      be bootstrapped externally using interfaces provided by the configured
-      authorization extension.
-    </description>
-    <value-attributes>
-      <empty-value-valid>true</empty-value-valid>
-    </value-attributes>
-  </property>
-
-  <property>
     <name>security.authorization.cache.ttl.secs</name>
     <value>300</value>
     <description>
@@ -3022,6 +3058,17 @@
       containing the extension code. This jar is only used when
       authorization is enabled by setting ${security.authorization.enabled}
       to true.
+    </description>
+    <value-attributes>
+      <empty-value-valid>true</empty-value-valid>
+    </value-attributes>
+  </property>
+
+  <property>
+    <name>security.authorization.extension.extra.classpath</name>
+    <value></value>
+    <description>
+      Extra Java classpath for CDAP security extension.
     </description>
     <value-attributes>
       <empty-value-valid>true</empty-value-valid>

--- a/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-site.xml
+++ b/src/main/resources/common-services/CDAP/4.0.0/configuration/cdap-site.xml
@@ -188,6 +188,14 @@
   </property>
 
   <property>
+    <name>twill.java.heap.memory.ratio</name>
+    <value>0.6</value>
+    <description>
+      The minimum ratio of heap to non-heap memory for Apache Twill container
+    </description>
+  </property>
+
+  <property>
     <name>twill.location.cache.dir</name>
     <value>.cache</value>
     <description>The relative directory name on the distributed file system for Apache Twill to cache
@@ -368,6 +376,18 @@
     <name>app.program.jvm.opts</name>
     <value>-XX:MaxPermSize=128M ${twill.jvm.gc.opts} -Dhdp.version=${hdp.version}</value>
     <description>Java options for all program containers</description>
+  </property>
+
+  <property>
+    <name>app.program.metrics.enabled</name>
+    <value>true</value>
+    <description>
+      Enable or disable emitting metrics from user application programs, by default set to true.
+    </description>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <property>
@@ -1527,11 +1547,47 @@
   </property>
 
   <property>
+    <name>messaging.table.hbase.split.policy</name>
+    <value>org.apache.hadoop.hbase.regionserver.DisabledRegionSplitPolicy</value>
+    <description>
+      The class name that controls the HBase table region split policy.
+      Ideally, auto-splitting should be disabled for HBase tables used by the messaging system.
+    </description>
+  </property>
+
+  <property>
     <name>messaging.topic.default.ttl.seconds</name>
     <value>604800</value>
     <description>
       The default time-to-live in seconds for messages in a topic
     </description>
+  </property>
+
+  <property>
+    <!-- Use lower heap memory ratio for the messaging service, since it uses non-heap memory for the connections -->
+    <name>messaging.twill.java.heap.memory.ratio</name>
+    <value>0.6</value>
+    <description>
+      The minimum ratio of heap to non-heap memory for the messaging service container
+    </description>
+  </property>
+
+  <property>
+    <!-- Use higher reserved memory setting for the messaging service, since it uses non-heap memory for connections -->
+    <name>messaging.twill.java.reserved.memory.mb</name>
+    <value>512</value>
+    <description>
+      Desired reserved non-heap memory in megabytes for the messaging service container.
+      The actual value is bounded by the ${twill.java.heap.memory.ratio} setting of the container memory size.
+    </description>
+    <value-attributes>
+      <type>int</type>
+      <minimum>256</minimum>
+      <maximum>65536</maximum>
+      <unit>MB</unit>
+      <increment-step>256</increment-step>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <!-- Security configuration -->
@@ -1643,6 +1699,14 @@
     <name>metrics.exec.threads</name>
     <value>${http.service.exec.threads}</value>
     <description>Number of Netty service executor threads for metrics HTTP services</description>
+  </property>
+
+  <property>
+    <name>metrics.hbase.max.scan.threads</name>
+    <value>96</value>
+    <description>
+      Maximum number of threads used for scanning HBase tables
+    </description>
   </property>
 
   <property>
@@ -1824,6 +1888,18 @@
     <description>
       Number of Netty service worker threads for metrics HTTP services
     </description>
+  </property>
+
+  <property>
+    <name>metrics.v2.table.scan.enabled</name>
+    <value>false</value>
+    <description>
+      Enable or disable scanning v2 metrics tables. By default set to false.
+    </description>
+    <value-attributes>
+      <type>boolean</type>
+      <overridable>false</overridable>
+    </value-attributes>
   </property>
 
   <!-- Monitor Handler Configuration -->
@@ -2949,35 +3025,6 @@
     </description>
     <value-attributes>
       <empty-value-valid>true</empty-value-valid>
-    </value-attributes>
-  </property>
-
-  <property>
-    <name>security.authorization.propagate.privileges</name>
-    <value>true</value>
-    <description>
-      Allows the propagation of privileges to descendants. If set to 'true', then having a
-      privilege on an entity will allow the user to perform actions on all the descendants
-      of that entity. For example, if set to 'true', then having READ on a namespace will
-      allow a user to READ all datasets in that namespace. If set to 'false', then users
-      will need privileges on each entity an action is performed on.
-    </description>
-    <value-attributes>
-      <type>boolean</type>
-    </value-attributes>
-    <value-attributes>
-      <type>value-list</type>
-      <entries>
-        <entry>
-          <value>true</value>
-          <label>Enabled</label>
-        </entry>
-        <entry>
-          <value>false</value>
-          <label>Disabled</label>
-        </entry>
-      </entries>
-      <selection-cardinality>1</selection-cardinality>
     </value-attributes>
   </property>
 

--- a/src/main/resources/stacks/HDP/2.0.6/services/CDAP/repos/repoinfo.xml
+++ b/src/main/resources/stacks/HDP/2.0.6/services/CDAP/repos/repoinfo.xml
@@ -17,36 +17,36 @@
 <reposinfo>
   <os family="redhat6">
     <repo>
-      <baseurl>http://repository.cask.co/centos/6/x86_64/cdap/4.2</baseurl>
-      <repoid>CDAP-4.2</repoid>
+      <baseurl>http://repository.cask.co/centos/6/x86_64/cdap/4.3</baseurl>
+      <repoid>CDAP-4.3</repoid>
       <reponame>CDAP</reponame>
     </repo>
   </os>
   <os family="redhat7">
     <repo>
-      <baseurl>http://repository.cask.co/centos/6/x86_64/cdap/4.2</baseurl>
-      <repoid>CDAP-4.2</repoid>
+      <baseurl>http://repository.cask.co/centos/6/x86_64/cdap/4.3</baseurl>
+      <repoid>CDAP-4.3</repoid>
       <reponame>CDAP</reponame>
     </repo>
   </os>
   <os family="ubuntu12">
     <repo>
-      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</baseurl>
-      <repoid>CDAP-4.2</repoid>
+      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.3</baseurl>
+      <repoid>CDAP-4.3</repoid>
       <reponame>CDAP</reponame>
     </repo>
   </os>
   <os family="ubuntu14">
     <repo>
-      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</baseurl>
-      <repoid>CDAP-4.2</repoid>
+      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.3</baseurl>
+      <repoid>CDAP-4.3</repoid>
       <reponame>CDAP</reponame>
     </repo>
   </os>
   <os family="ubuntu16">
     <repo>
-      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.2</baseurl>
-      <repoid>CDAP-4.2</repoid>
+      <baseurl>http://repository.cask.co/ubuntu/precise/amd64/cdap/4.3</baseurl>
+      <repoid>CDAP-4.3</repoid>
       <reponame>CDAP</reponame>
     </repo>
   </os>


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12235
Update properties

Added in 4.3
- app.program.metrics.enabled
- messaging.twill.java.heap.memory.ratio
- messaging.twill.java.reserved.memory.mb
- metrics.hbase.max.scan.threads
- metrics.v2.table.scan.enabled
- program.message.retry.policy.base.delay.ms
- program.message.retry.policy.max.delay.ms
- program.message.retry.policy.max.retries
- program.message.retry.policy.max.time.secs
- program.message.retry.policy.type
- program.status.event.topic
- security.authorization.extension.extra.classpath (Added but it's not in the cdap-default.xml)
- messaging.table.hbase.split.policy (left out of the service because it's not recommended to change form the default value)

New default value
- twill.java.heap.memory.ratio(0.6)

Removed in 4.3
- messaging.coprocessor.dir
- security.authorization.propagate.privileges
- security.authorization.admin.users