### PR TITLE
update python versions, 2.6 no longer supported by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@
 
 language: python
 python:
-  - 2.6
   - 2.7
+  - 3.6
 before_install:
   - sudo apt-get install -y libxml2-utils
 sudo: false


### PR DESCRIPTION
cherry-pick of https://github.com/cdapio/cdap-ambari-service/pull/307